### PR TITLE
Show pull progress during image pull and build

### DIFF
--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -774,6 +774,66 @@ func TestStreamBuildOutputEmpty(t *testing.T) {
 	}
 }
 
+func TestStreamBuildOutputPullProgress(t *testing.T) {
+	// Docker emits pull progress events (status/id/progress) during FROM pulls.
+	// Only meaningful state transitions should be shown; intermediate noise
+	// (Waiting, Downloading, Extracting, Verifying Checksum) must be suppressed.
+	input := `{"status":"Pulling from linuxserver/webtop","id":"ubuntu-xfce"}
+{"status":"Pulling fs layer","progressDetail":{},"id":"abc12345"}
+{"status":"Waiting","progressDetail":{},"id":"abc12345"}
+{"status":"Downloading","progressDetail":{"current":100,"total":1000},"progress":"[=>  ]","id":"abc12345"}
+{"status":"Verifying Checksum","progressDetail":{},"id":"abc12345"}
+{"status":"Download complete","progressDetail":{},"id":"abc12345"}
+{"status":"Extracting","progressDetail":{},"id":"abc12345"}
+{"status":"Pull complete","progressDetail":{},"id":"abc12345"}
+{"status":"Digest: sha256:deadbeef"}
+{"status":"Status: Downloaded newer image for linuxserver/webtop:ubuntu-xfce"}
+{"stream":"Step 1/9 : FROM lscr.io/linuxserver/webtop:ubuntu-xfce\n"}
+`
+	var output bytes.Buffer
+	if err := streamBuildOutput(strings.NewReader(input), &output); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := output.String()
+
+	// Meaningful events must appear
+	if !strings.Contains(got, "ubuntu-xfce: Pulling from linuxserver/webtop") {
+		t.Error("missing pull-from line")
+	}
+	if !strings.Contains(got, "abc12345: Pull complete") {
+		t.Error("missing pull-complete line")
+	}
+	if !strings.Contains(got, "Digest: sha256:deadbeef") {
+		t.Error("missing digest line")
+	}
+	if !strings.Contains(got, "Status: Downloaded newer image") {
+		t.Error("missing status line")
+	}
+
+	// Noisy intermediate events must be suppressed
+	if strings.Contains(got, "Pulling fs layer") {
+		t.Error("'Pulling fs layer' should be suppressed")
+	}
+	if strings.Contains(got, "Waiting") {
+		t.Error("'Waiting' should be suppressed")
+	}
+	if strings.Contains(got, "[=>  ]") {
+		t.Error("download progress bar should be suppressed")
+	}
+	if strings.Contains(got, "Extracting") {
+		t.Error("'Extracting' should be suppressed")
+	}
+	if strings.Contains(got, "Verifying Checksum") {
+		t.Error("'Verifying Checksum' should be suppressed")
+	}
+
+	// Regular stream events must still appear
+	if !strings.Contains(got, "Step 1/9") {
+		t.Error("missing stream output")
+	}
+}
+
 // --- templateFuncs ---
 
 func TestTemplateFuncRepeat(t *testing.T) {

--- a/internal/build/pipeline.go
+++ b/internal/build/pipeline.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/desktopus-org/desktopus/internal/config"
 	"github.com/desktopus-org/desktopus/internal/module"
+	"github.com/desktopus-org/desktopus/internal/progress"
 )
 
 //go:embed templates/*
@@ -250,10 +251,14 @@ func addRuntimeFiles(bctx *BuildContext, cfg *config.DesktopConfig) error {
 
 func streamBuildOutput(reader io.Reader, output io.Writer) error {
 	decoder := json.NewDecoder(reader)
+	pr := progress.New(output)
 	for {
 		var msg struct {
-			Stream string `json:"stream"`
-			Error  string `json:"error"`
+			Stream   string `json:"stream"`
+			Error    string `json:"error"`
+			Status   string `json:"status"`
+			Progress string `json:"progress"`
+			ID       string `json:"id"`
 		}
 		if err := decoder.Decode(&msg); err != nil {
 			if err == io.EOF {
@@ -262,10 +267,20 @@ func streamBuildOutput(reader io.Reader, output io.Writer) error {
 			return err
 		}
 		if msg.Error != "" {
+			pr.Clear()
 			return fmt.Errorf("build error: %s", msg.Error)
 		}
 		if msg.Stream != "" {
+			pr.Flush()
 			fmt.Fprint(output, msg.Stream)
+			continue
+		}
+		if msg.Status != "" {
+			if msg.ID != "" {
+				pr.Update(msg.ID, msg.Status, msg.Progress)
+			} else {
+				pr.Print(msg.Status)
+			}
 		}
 	}
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -80,7 +81,7 @@ var runCmd = &cobra.Command{
 		// Build the runtime config from the desktop config
 		runCfg := toDesktopRunConfig(cfg)
 
-		containerID, err := mgr.Run(context.Background(), runCfg, opts)
+		containerID, err := mgr.Run(context.Background(), runCfg, opts, os.Stdout)
 		if err != nil {
 			return fmt.Errorf("failed to run desktop: %w", err)
 		}

--- a/internal/progress/pull.go
+++ b/internal/progress/pull.go
@@ -1,0 +1,153 @@
+package progress
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+// Renderer displays Docker image pull progress.
+// In TTY mode each layer occupies one line, updated in-place via ANSI codes,
+// with a braille spinner on in-progress layers.
+// In non-TTY mode only meaningful state transitions are printed.
+type Renderer struct {
+	w          io.Writer
+	isTTY      bool
+	order      []string
+	states     map[string]*layerState
+	drawn      int
+	spinnerIdx int
+}
+
+type layerState struct {
+	status   string
+	progress string // Docker's pre-formatted bar, e.g. "[======>   ]  45MB/89MB"
+}
+
+// New returns a Renderer that writes to w.
+func New(w io.Writer) *Renderer {
+	return &Renderer{
+		w:      w,
+		isTTY:  isTerminal(w),
+		states: make(map[string]*layerState),
+	}
+}
+
+// newForTest returns a Renderer with an explicit TTY setting, for use in tests.
+func newForTest(w io.Writer, isTTY bool) *Renderer {
+	return &Renderer{
+		w:      w,
+		isTTY:  isTTY,
+		states: make(map[string]*layerState),
+	}
+}
+
+// Update records a layer event and refreshes the display.
+func (r *Renderer) Update(id, status, progress string) {
+	if r.isTTY {
+		if _, ok := r.states[id]; !ok {
+			r.order = append(r.order, id)
+			r.states[id] = &layerState{}
+		}
+		r.states[id].status = status
+		r.states[id].progress = progress
+		r.redraw()
+	} else {
+		if isMeaningfulStatus(status) {
+			fmt.Fprintf(r.w, "%s: %s\n", id, status)
+		}
+	}
+}
+
+// Print writes a summary line with no layer ID (e.g. "Digest:", "Status:").
+// In TTY mode it finalises the layer display first.
+func (r *Renderer) Print(line string) {
+	if r.isTTY {
+		r.Flush()
+	}
+	fmt.Fprintf(r.w, "%s\n", line)
+}
+
+// Flush finalises the in-place display: redraws all layers as static output
+// and resets state. Safe to call when nothing has been drawn yet.
+func (r *Renderer) Flush() {
+	if !r.isTTY || r.drawn == 0 {
+		return
+	}
+	r.clearLines(r.drawn)
+	for _, id := range r.order {
+		fmt.Fprintf(r.w, "%s: %s\n", id, r.states[id].status)
+	}
+	// Reset so a subsequent pull (e.g. multi-stage FROM) starts fresh.
+	r.drawn = 0
+	r.order = nil
+	r.states = make(map[string]*layerState)
+}
+
+// Clear removes the in-progress display without printing a final state.
+func (r *Renderer) Clear() {
+	r.clearLines(r.drawn)
+	r.drawn = 0
+	r.order = nil
+	r.states = make(map[string]*layerState)
+}
+
+func (r *Renderer) redraw() {
+	r.clearLines(r.drawn)
+	r.drawn = 0
+	spin := spinnerFrames[r.spinnerIdx%len(spinnerFrames)]
+	r.spinnerIdx++
+	for _, id := range r.order {
+		s := r.states[id]
+		switch {
+		case isLayerDone(s.status) || strings.HasPrefix(s.status, "Pulling from"):
+			// Done or header line: static, no spinner.
+			fmt.Fprintf(r.w, "  %s: %s\n", id, s.status)
+		case s.progress != "":
+			// Active with a progress bar from Docker.
+			fmt.Fprintf(r.w, "%s %s: %s %s\n", spin, id, s.status, s.progress)
+		default:
+			// Active without a progress bar: show spinner + status only.
+			fmt.Fprintf(r.w, "%s %s: %s\n", spin, id, s.status)
+		}
+		r.drawn++
+	}
+}
+
+func isLayerDone(status string) bool {
+	return status == "Pull complete" || status == "Already exists"
+}
+
+func (r *Renderer) clearLines(n int) {
+	for i := 0; i < n; i++ {
+		fmt.Fprint(r.w, "\033[1A\033[2K")
+	}
+}
+
+// isMeaningfulStatus reports whether a pull status is worth printing in
+// non-TTY mode — i.e. it signals a real state change rather than churn.
+func isMeaningfulStatus(status string) bool {
+	switch status {
+	case "Pull complete", "Already exists", "Download complete":
+		return true
+	}
+	return strings.HasPrefix(status, "Pulling from") ||
+		strings.HasPrefix(status, "Digest:") ||
+		strings.HasPrefix(status, "Status:")
+}
+
+// isTerminal reports whether w is a character device (i.e. a terminal).
+func isTerminal(w io.Writer) bool {
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	fi, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}

--- a/internal/progress/pull_test.go
+++ b/internal/progress/pull_test.go
@@ -1,0 +1,225 @@
+package progress
+
+import (
+	"strings"
+	"testing"
+)
+
+// nonTTYWriter wraps a strings.Builder so isTerminal returns false.
+type nonTTYWriter struct{ b strings.Builder }
+
+func (w *nonTTYWriter) Write(p []byte) (int, error) { return w.b.Write(p) }
+func (w *nonTTYWriter) String() string               { return w.b.String() }
+
+// --- non-TTY mode ---
+
+func TestRendererNonTTY_MeaningfulEventsOnly(t *testing.T) {
+	w := &nonTTYWriter{}
+	r := New(w)
+
+	r.Update("abc123", "Pulling fs layer", "")
+	r.Update("abc123", "Waiting", "")
+	r.Update("abc123", "Downloading", "[=>   ] 1MB/50MB")
+	r.Update("abc123", "Verifying Checksum", "")
+	r.Update("abc123", "Download complete", "")
+	r.Update("abc123", "Extracting", "")
+	r.Update("abc123", "Pull complete", "")
+	r.Print("Digest: sha256:deadbeef")
+	r.Print("Status: Downloaded newer image for ubuntu:latest")
+
+	got := w.String()
+
+	if !strings.Contains(got, "abc123: Download complete") {
+		t.Error("missing 'Download complete'")
+	}
+	if !strings.Contains(got, "abc123: Pull complete") {
+		t.Error("missing 'Pull complete'")
+	}
+	if !strings.Contains(got, "Digest: sha256:deadbeef") {
+		t.Error("missing digest line")
+	}
+	if !strings.Contains(got, "Status: Downloaded newer image") {
+		t.Error("missing status line")
+	}
+
+	for _, noise := range []string{"Pulling fs layer", "Waiting", "[=>   ]", "Verifying Checksum", "Extracting"} {
+		if strings.Contains(got, noise) {
+			t.Errorf("noisy event %q should be suppressed", noise)
+		}
+	}
+}
+
+func TestRendererNonTTY_AlreadyExists(t *testing.T) {
+	w := &nonTTYWriter{}
+	r := New(w)
+
+	r.Update("abc123", "Already exists", "")
+	r.Print("Digest: sha256:deadbeef")
+	r.Print("Status: Image is up to date for ubuntu:latest")
+
+	got := w.String()
+
+	if !strings.Contains(got, "abc123: Already exists") {
+		t.Error("missing 'Already exists'")
+	}
+	if !strings.Contains(got, "Status: Image is up to date") {
+		t.Error("missing up-to-date status")
+	}
+}
+
+func TestRendererNonTTY_FlushBeforePullEventsDoesNotSuppressOutput(t *testing.T) {
+	// streamBuildOutput calls Flush() on every stream event (e.g. "Step 1/9 : FROM...")
+	// before any pull events arrive. Flush() must not silence subsequent Update() calls.
+	w := &nonTTYWriter{}
+	r := New(w)
+
+	r.Flush() // simulates a stream event arriving before any pull events
+	r.Update("abc123", "Pull complete", "")
+	r.Print("Digest: sha256:deadbeef")
+
+	got := w.String()
+
+	if !strings.Contains(got, "abc123: Pull complete") {
+		t.Error("Pull complete should appear even after an early Flush()")
+	}
+	if !strings.Contains(got, "Digest: sha256:deadbeef") {
+		t.Error("Digest line should appear")
+	}
+}
+
+// --- TTY mode ---
+
+func TestRendererTTY_SpinnerOnActiveLayer(t *testing.T) {
+	w := &nonTTYWriter{}
+	r := newForTest(w, true)
+
+	r.Update("abc123", "Waiting", "")
+
+	got := w.String()
+
+	// A spinner character from the braille set should appear.
+	found := false
+	for _, frame := range spinnerFrames {
+		if strings.Contains(got, frame) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a spinner character on active layer, got: %q", got)
+	}
+	if !strings.Contains(got, "abc123: Waiting") {
+		t.Error("missing layer status")
+	}
+}
+
+func TestRendererTTY_NospinnerOnDoneLayer(t *testing.T) {
+	w := &nonTTYWriter{}
+	r := newForTest(w, true)
+
+	r.Update("abc123", "Pull complete", "")
+
+	got := w.String()
+
+	for _, frame := range spinnerFrames {
+		if strings.Contains(got, frame) {
+			t.Errorf("completed layer should not show spinner, got: %q", got)
+		}
+	}
+	if !strings.Contains(got, "abc123: Pull complete") {
+		t.Error("missing completed layer status")
+	}
+}
+
+func TestRendererTTY_SpinnerOnDownloadingWithProgressBar(t *testing.T) {
+	w := &nonTTYWriter{}
+	r := newForTest(w, true)
+
+	r.Update("abc123", "Downloading", "[====>   ] 45MB/89MB")
+
+	got := w.String()
+
+	// Spinner should appear alongside the progress bar.
+	found := false
+	for _, frame := range spinnerFrames {
+		if strings.Contains(got, frame) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected spinner on downloading layer, got: %q", got)
+	}
+	if !strings.Contains(got, "[====>   ] 45MB/89MB") {
+		t.Error("progress bar should still appear")
+	}
+}
+
+func TestRendererTTY_PullingFromHeaderNoSpinner(t *testing.T) {
+	w := &nonTTYWriter{}
+	r := newForTest(w, true)
+
+	r.Update("ubuntu-xfce", "Pulling from linuxserver/webtop", "")
+
+	got := w.String()
+
+	for _, frame := range spinnerFrames {
+		if strings.Contains(got, frame) {
+			t.Errorf("'Pulling from' header should not show spinner, got: %q", got)
+		}
+	}
+	if !strings.Contains(got, "Pulling from linuxserver/webtop") {
+		t.Error("missing 'Pulling from' header")
+	}
+}
+
+func TestRendererTTY_FlushPrintsStaticOutput(t *testing.T) {
+	w := &nonTTYWriter{}
+	r := newForTest(w, true)
+
+	r.Update("abc123", "Pull complete", "")
+	r.Update("def456", "Waiting", "")
+
+	// Clear ANSI noise for assertion purposes.
+	r.Flush()
+
+	got := w.String()
+	// After Flush, both layers should appear as plain "id: status" lines.
+	if !strings.Contains(got, "abc123: Pull complete") {
+		t.Error("missing static Pull complete line after Flush")
+	}
+	if !strings.Contains(got, "def456: Waiting") {
+		t.Error("missing static Waiting line after Flush")
+	}
+}
+
+// --- isMeaningfulStatus ---
+
+func TestIsMeaningfulStatus(t *testing.T) {
+	meaningful := []string{
+		"Pull complete",
+		"Already exists",
+		"Download complete",
+		"Pulling from linuxserver/webtop",
+		"Digest: sha256:abc",
+		"Status: Downloaded newer image",
+	}
+	for _, s := range meaningful {
+		if !isMeaningfulStatus(s) {
+			t.Errorf("%q should be meaningful", s)
+		}
+	}
+
+	noisy := []string{
+		"Pulling fs layer",
+		"Waiting",
+		"Downloading",
+		"Extracting",
+		"Verifying Checksum",
+	}
+	for _, s := range noisy {
+		if isMeaningfulStatus(s) {
+			t.Errorf("%q should not be meaningful", s)
+		}
+	}
+}

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -2,7 +2,9 @@ package runtime
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/netip"
 	"os"
 	"strconv"
@@ -12,6 +14,8 @@ import (
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
+
+	"github.com/desktopus-org/desktopus/internal/progress"
 )
 
 // Manager handles container lifecycle via the Docker SDK
@@ -24,8 +28,13 @@ func NewManager(docker *client.Client) *Manager {
 	return &Manager{docker: docker}
 }
 
-// Run creates and starts a container from a desktop config
-func (m *Manager) Run(ctx context.Context, cfg *DesktopRunConfig, opts RunOptions) (string, error) {
+// Run creates and starts a container from a desktop config.
+// output receives pull progress if the image is not present locally.
+func (m *Manager) Run(ctx context.Context, cfg *DesktopRunConfig, opts RunOptions, output io.Writer) (string, error) {
+	if err := m.pullIfMissing(ctx, cfg.ImageTag, output); err != nil {
+		return "", err
+	}
+
 	containerName := cfg.Name
 	if opts.Name != "" {
 		containerName = opts.Name
@@ -100,6 +109,55 @@ func (m *Manager) Run(ctx context.Context, cfg *DesktopRunConfig, opts RunOption
 	}
 
 	return resp.ID, nil
+}
+
+// pullIfMissing pulls the image if it is not already present locally.
+func (m *Manager) pullIfMissing(ctx context.Context, image string, output io.Writer) error {
+	_, err := m.docker.ImageInspect(ctx, image)
+	if err == nil {
+		return nil
+	}
+
+	fmt.Fprintf(output, "Pulling %s...\n", image)
+	rc, err := m.docker.ImagePull(ctx, image, client.ImagePullOptions{})
+	if err != nil {
+		return fmt.Errorf("pulling image %s: %w", image, err)
+	}
+	defer rc.Close()
+
+	return streamPullOutput(rc, output)
+}
+
+func streamPullOutput(reader io.Reader, output io.Writer) error {
+	decoder := json.NewDecoder(reader)
+	pr := progress.New(output)
+	for {
+		var event struct {
+			Status   string `json:"status"`
+			Progress string `json:"progress"`
+			ID       string `json:"id"`
+			Error    string `json:"error"`
+		}
+		if err := decoder.Decode(&event); err != nil {
+			if err == io.EOF {
+				pr.Flush()
+				return nil
+			}
+			return err
+		}
+		if event.Error != "" {
+			pr.Clear()
+			return fmt.Errorf("%s", event.Error)
+		}
+		if event.Status == "" {
+			continue
+		}
+		if event.ID != "" {
+			pr.Update(event.ID, event.Status, event.Progress)
+		} else {
+			pr.Print(event.Status)
+		}
+	}
 }
 
 // Stop stops a container by name or ID

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/moby/moby/api/types/container"
@@ -190,5 +191,64 @@ func TestFormatPortsNoPublic(t *testing.T) {
 	result := formatPorts(ports)
 	if result != "-" {
 		t.Errorf("expected '-' for no public ports, got %q", result)
+	}
+}
+
+func TestStreamPullOutput(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr string
+	}{
+		{
+			name: "only meaningful events are shown",
+			input: `{"status":"Pulling from linuxserver/webtop","id":"latest"}
+{"status":"Pulling fs layer","id":"abc12345"}
+{"status":"Waiting","id":"abc12345"}
+{"status":"Downloading","progressDetail":{"current":100,"total":1000},"progress":"[=>  ]","id":"abc12345"}
+{"status":"Verifying Checksum","id":"abc12345"}
+{"status":"Download complete","id":"abc12345"}
+{"status":"Extracting","id":"abc12345"}
+{"status":"Pull complete","id":"abc12345"}
+{"status":"Digest: sha256:deadbeef"}
+{"status":"Status: Downloaded newer image for linuxserver/webtop:latest"}
+`,
+			want: "latest: Pulling from linuxserver/webtop\nabc12345: Download complete\nabc12345: Pull complete\nDigest: sha256:deadbeef\nStatus: Downloaded newer image for linuxserver/webtop:latest\n",
+		},
+		{
+			name:    "error event returns error",
+			input:   `{"error":"pull access denied"}`,
+			wantErr: "pull access denied",
+		},
+		{
+			name:  "empty stream",
+			input: ``,
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf strings.Builder
+			err := streamPullOutput(strings.NewReader(tt.input), &buf)
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("expected error %q, got %q", tt.wantErr, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if buf.String() != tt.want {
+				t.Errorf("output mismatch\ngot:  %q\nwant: %q", buf.String(), tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- **`desktopus build`**: Docker pull events for the `FROM` base image were silently dropped — `streamBuildOutput` only handled `stream` events and ignored the `status`/`progress` JSON events Docker emits during layer downloads
- **`desktopus run`**: if the image wasn't cached locally, Docker would pull it silently with no output; now `pullIfMissing` is called before `ContainerCreate` to stream pull progress
- A shared `internal/progress` renderer handles both cases, with two modes:
  - **TTY**: braille spinner (`⠋⠙⠹…`) on each in-progress layer, progress bar when Docker provides one, static output for completed layers
  - **non-TTY** (CI/piped): only meaningful state transitions printed (`Pull complete`, `Already exists`, `Digest`, `Status`)

## Test plan

- [x] `mage build` then `desktopus build` with base image not cached — pull progress animates in terminal
- [x] `desktopus run` with image not cached locally — pull progress shown before container starts
- [x] Pipe output (`desktopus build 2>&1 | cat`) — clean non-TTY output with no spinner noise
- [x] `go test ./...` passes