### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run tests
+        run: go test ./...
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v9

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,9 @@
+version: "2"
+
+linters:
+  settings:
+    errcheck:
+      exclude-functions:
+        - fmt.Fprint
+        - fmt.Fprintf
+        - fmt.Fprintln

--- a/internal/build/pipeline.go
+++ b/internal/build/pipeline.go
@@ -127,7 +127,7 @@ func (p *Pipeline) Build(ctx context.Context, cfg *config.DesktopConfig, configD
 	if err != nil {
 		return fmt.Errorf("starting build: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	// 9. Stream build output
 	return streamBuildOutput(resp.Body, output)
@@ -272,7 +272,7 @@ func streamBuildOutput(reader io.Reader, output io.Writer) error {
 		}
 		if msg.Stream != "" {
 			pr.Flush()
-			fmt.Fprint(output, msg.Stream)
+			_, _ = fmt.Fprint(output, msg.Stream)
 			continue
 		}
 		if msg.Status != "" {

--- a/internal/build/pipeline.go
+++ b/internal/build/pipeline.go
@@ -272,7 +272,7 @@ func streamBuildOutput(reader io.Reader, output io.Writer) error {
 		}
 		if msg.Stream != "" {
 			pr.Flush()
-			_, _ = fmt.Fprint(output, msg.Stream)
+			fmt.Fprint(output, msg.Stream)
 			continue
 		}
 		if msg.Status != "" {

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -49,7 +49,7 @@ var buildCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		defer dockerClient.Close()
+		defer func() { _ = dockerClient.Close() }()
 
 		// Create module registry
 		registry, err := module.NewRegistry(modules.BuiltinFS)

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -41,9 +41,9 @@ var listCmd = &cobra.Command{
 		}
 
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-		_, _ = fmt.Fprintln(w, "NAME\tIMAGE\tSTATUS\tPORTS")
+		fmt.Fprintln(w, "NAME\tIMAGE\tSTATUS\tPORTS")
 		for _, c := range containers {
-			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", c.Name, c.Image, c.State, c.Ports)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", c.Name, c.Image, c.State, c.Ports)
 		}
 		return w.Flush()
 	},

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -24,7 +24,7 @@ var listCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		defer dockerClient.Close()
+		defer func() { _ = dockerClient.Close() }()
 
 		mgr := runtime.NewManager(dockerClient)
 		containers, err := mgr.List(context.Background(), listAll)
@@ -41,9 +41,9 @@ var listCmd = &cobra.Command{
 		}
 
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-		fmt.Fprintln(w, "NAME\tIMAGE\tSTATUS\tPORTS")
+		_, _ = fmt.Fprintln(w, "NAME\tIMAGE\tSTATUS\tPORTS")
 		for _, c := range containers {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", c.Name, c.Image, c.State, c.Ports)
+			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", c.Name, c.Image, c.State, c.Ports)
 		}
 		return w.Flush()
 	},

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -55,7 +55,7 @@ var runCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		defer dockerClient.Close()
+		defer func() { _ = dockerClient.Close() }()
 
 		mgr := runtime.NewManager(dockerClient)
 

--- a/internal/cli/stop.go
+++ b/internal/cli/stop.go
@@ -27,7 +27,7 @@ var stopCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		defer dockerClient.Close()
+		defer func() { _ = dockerClient.Close() }()
 
 		mgr := runtime.NewManager(dockerClient)
 		ctx := context.Background()

--- a/internal/progress/pull.go
+++ b/internal/progress/pull.go
@@ -57,7 +57,7 @@ func (r *Renderer) Update(id, status, progress string) {
 		r.redraw()
 	} else {
 		if isMeaningfulStatus(status) {
-			_, _ = fmt.Fprintf(r.w, "%s: %s\n", id, status)
+			fmt.Fprintf(r.w, "%s: %s\n", id, status)
 		}
 	}
 }
@@ -68,7 +68,7 @@ func (r *Renderer) Print(line string) {
 	if r.isTTY {
 		r.Flush()
 	}
-	_, _ = fmt.Fprintf(r.w, "%s\n", line)
+	fmt.Fprintf(r.w, "%s\n", line)
 }
 
 // Flush finalises the in-place display: redraws all layers as static output
@@ -79,7 +79,7 @@ func (r *Renderer) Flush() {
 	}
 	r.clearLines(r.drawn)
 	for _, id := range r.order {
-		_, _ = fmt.Fprintf(r.w, "%s: %s\n", id, r.states[id].status)
+		fmt.Fprintf(r.w, "%s: %s\n", id, r.states[id].status)
 	}
 	// Reset so a subsequent pull (e.g. multi-stage FROM) starts fresh.
 	r.drawn = 0
@@ -105,13 +105,13 @@ func (r *Renderer) redraw() {
 		switch {
 		case isLayerDone(s.status) || strings.HasPrefix(s.status, "Pulling from"):
 			// Done or header line: static, no spinner.
-			_, _ = fmt.Fprintf(r.w, "  %s: %s\n", id, s.status)
+			fmt.Fprintf(r.w, "  %s: %s\n", id, s.status)
 		case s.progress != "":
 			// Active with a progress bar from Docker.
-			_, _ = fmt.Fprintf(r.w, "%s %s: %s %s\n", spin, id, s.status, s.progress)
+			fmt.Fprintf(r.w, "%s %s: %s %s\n", spin, id, s.status, s.progress)
 		default:
 			// Active without a progress bar: show spinner + status only.
-			_, _ = fmt.Fprintf(r.w, "%s %s: %s\n", spin, id, s.status)
+			fmt.Fprintf(r.w, "%s %s: %s\n", spin, id, s.status)
 		}
 		r.drawn++
 	}
@@ -123,7 +123,7 @@ func isLayerDone(status string) bool {
 
 func (r *Renderer) clearLines(n int) {
 	for i := 0; i < n; i++ {
-		_, _ = fmt.Fprint(r.w, "\033[1A\033[2K")
+		fmt.Fprint(r.w, "\033[1A\033[2K")
 	}
 }
 

--- a/internal/progress/pull.go
+++ b/internal/progress/pull.go
@@ -57,7 +57,7 @@ func (r *Renderer) Update(id, status, progress string) {
 		r.redraw()
 	} else {
 		if isMeaningfulStatus(status) {
-			fmt.Fprintf(r.w, "%s: %s\n", id, status)
+			_, _ = fmt.Fprintf(r.w, "%s: %s\n", id, status)
 		}
 	}
 }
@@ -68,7 +68,7 @@ func (r *Renderer) Print(line string) {
 	if r.isTTY {
 		r.Flush()
 	}
-	fmt.Fprintf(r.w, "%s\n", line)
+	_, _ = fmt.Fprintf(r.w, "%s\n", line)
 }
 
 // Flush finalises the in-place display: redraws all layers as static output
@@ -79,7 +79,7 @@ func (r *Renderer) Flush() {
 	}
 	r.clearLines(r.drawn)
 	for _, id := range r.order {
-		fmt.Fprintf(r.w, "%s: %s\n", id, r.states[id].status)
+		_, _ = fmt.Fprintf(r.w, "%s: %s\n", id, r.states[id].status)
 	}
 	// Reset so a subsequent pull (e.g. multi-stage FROM) starts fresh.
 	r.drawn = 0
@@ -105,13 +105,13 @@ func (r *Renderer) redraw() {
 		switch {
 		case isLayerDone(s.status) || strings.HasPrefix(s.status, "Pulling from"):
 			// Done or header line: static, no spinner.
-			fmt.Fprintf(r.w, "  %s: %s\n", id, s.status)
+			_, _ = fmt.Fprintf(r.w, "  %s: %s\n", id, s.status)
 		case s.progress != "":
 			// Active with a progress bar from Docker.
-			fmt.Fprintf(r.w, "%s %s: %s %s\n", spin, id, s.status, s.progress)
+			_, _ = fmt.Fprintf(r.w, "%s %s: %s %s\n", spin, id, s.status, s.progress)
 		default:
 			// Active without a progress bar: show spinner + status only.
-			fmt.Fprintf(r.w, "%s %s: %s\n", spin, id, s.status)
+			_, _ = fmt.Fprintf(r.w, "%s %s: %s\n", spin, id, s.status)
 		}
 		r.drawn++
 	}
@@ -123,7 +123,7 @@ func isLayerDone(status string) bool {
 
 func (r *Renderer) clearLines(n int) {
 	for i := 0; i < n; i++ {
-		fmt.Fprint(r.w, "\033[1A\033[2K")
+		_, _ = fmt.Fprint(r.w, "\033[1A\033[2K")
 	}
 }
 

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -76,11 +76,11 @@ func (m *Manager) Run(ctx context.Context, cfg *DesktopRunConfig, opts RunOption
 
 	if cfg.Memory != "" {
 		if mem := parseSize(cfg.Memory); mem > 0 {
-			hostCfg.Resources.Memory = mem
+			hostCfg.Memory = mem
 		}
 	}
 	if cfg.CPUs > 0 {
-		hostCfg.Resources.NanoCPUs = int64(cfg.CPUs) * 1e9
+		hostCfg.NanoCPUs = int64(cfg.CPUs) * 1e9
 	}
 
 	if cfg.GPU || opts.GPU {
@@ -123,7 +123,7 @@ func (m *Manager) pullIfMissing(ctx context.Context, image string, output io.Wri
 	if err != nil {
 		return fmt.Errorf("pulling image %s: %w", image, err)
 	}
-	defer rc.Close()
+	defer func() { _ = rc.Close() }()
 
 	return streamPullOutput(rc, output)
 }


### PR DESCRIPTION
## Summary
- Adds a CI workflow that runs on every push to `main` and on all pull requests
- Two parallel jobs: **Test** (`go test ./...`) and **Lint** (`golangci-lint`)
- Uses `go-version-file: go.mod` to avoid hardcoding the Go version
- All actions pinned to current latest major versions (checkout@v6, setup-go@v6, golangci-lint-action@v9)