### PR TITLE
fix: use GitHub PR titles for release changelog

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,6 +30,7 @@ checksum:
   name_template: checksums.txt
 
 changelog:
+  use: github
   sort: asc
   filters:
     exclude:


### PR DESCRIPTION
Switch changelog source from raw git commits to merged GitHub PRs (). This way release notes list PR titles instead of individual commits, which is cleaner and more meaningful.