### PR TITLE
fix: Chrome sandbox and signing key fixes for all OSes

### DIFF
--- a/internal/module/types.go
+++ b/internal/module/types.go
@@ -19,6 +19,8 @@ type Module struct {
 
 	// OSTaskFiles maps OS names to true if tasks/<os>.yml exists
 	OSTaskFiles map[string]bool `yaml:"-"`
+
+	SmokeTest *SmokeTest `yaml:"smoke_test,omitempty"`
 }
 
 // Compatibility defines which OS/desktop/arch combos a module supports
@@ -26,6 +28,25 @@ type Compatibility struct {
 	OS      []string `yaml:"os,omitempty"`
 	Desktop []string `yaml:"desktop,omitempty"`
 	Arch    []string `yaml:"arch,omitempty"`
+}
+
+// SmokeTest defines commands to run inside a built image to verify the module works.
+// Each entry is a separate command. Default is used for all OSes unless an OS-specific
+// override is present.
+type SmokeTest struct {
+	Default [][]string            `yaml:"default,omitempty"`
+	OS      map[string][][]string `yaml:"os,omitempty"`
+}
+
+// SmokeCmds returns the smoke test commands for the given OS, or nil if none are defined.
+func (m *Module) SmokeCmds(targetOS string) [][]string {
+	if m.SmokeTest == nil {
+		return nil
+	}
+	if cmds, ok := m.SmokeTest.OS[targetOS]; ok {
+		return cmds
+	}
+	return m.SmokeTest.Default
 }
 
 // Var defines a module variable

--- a/modules/chrome/module.yaml
+++ b/modules/chrome/module.yaml
@@ -14,3 +14,12 @@ vars:
     description: "Chrome release channel (stable, beta, unstable)"
 
 system_packages: [wget, gnupg]
+
+smoke_test:
+  default:
+    - ["/usr/local/bin/google-chrome", "--version"]
+    - ["sh", "-c", "exec $(grep -m1 '^Exec=' /usr/share/applications/google-chrome.desktop | sed 's/^Exec=//;s/ %[A-Za-z]//g') --version"]
+  os:
+    alpine:
+      - ["/usr/local/bin/chromium", "--version"]
+      - ["sh", "-c", "exec $(grep -m1 '^Exec=' /usr/share/applications/chromium.desktop | sed 's/^Exec=//;s/ %[A-Za-z]//g') --version"]

--- a/modules/chrome/tasks/alpine.yml
+++ b/modules/chrome/tasks/alpine.yml
@@ -7,6 +7,12 @@
     name: chromium
     state: present
 
+- name: Patch Chromium desktop file to add --no-sandbox (required in containers)
+  ansible.builtin.replace:
+    path: /usr/share/applications/chromium.desktop
+    regexp: '^(Exec=chromium[^ ]*)(.*)'
+    replace: '\1 --no-sandbox\2'
+
 - name: Ensure Desktop directory exists
   ansible.builtin.file:
     path: "{{ desktopus_home }}/Desktop"

--- a/modules/chrome/tasks/alpine.yml
+++ b/modules/chrome/tasks/alpine.yml
@@ -7,11 +7,29 @@
     name: chromium
     state: present
 
-- name: Patch Chromium desktop file to add --no-sandbox (required in containers)
+- name: Create Chromium wrapper script
+  ansible.builtin.copy:
+    dest: /usr/local/bin/chromium
+    mode: "0755"
+    content: |
+      #!/bin/bash
+      BIN=/usr/bin/chromium-browser
+
+      if ! pgrep chromium > /dev/null; then
+        rm -f "$HOME/.config/chromium/Singleton"*
+      fi
+
+      if grep -q 'Seccomp:.0' /proc/1/status; then
+        ${BIN} --no-first-run --password-store=basic "$@"
+      else
+        ${BIN} --no-first-run --password-store=basic --no-sandbox --test-type "$@"
+      fi
+
+- name: Patch Chromium desktop file to use wrapper
   ansible.builtin.replace:
     path: /usr/share/applications/chromium.desktop
-    regexp: '^(Exec=chromium[^ ]*)(.*)'
-    replace: '\1 --no-sandbox\2'
+    regexp: '^(Exec=)[^ ]*(.*)'
+    replace: '\1/usr/local/bin/chromium\2'
 
 - name: Ensure Desktop directory exists
   ansible.builtin.file:

--- a/modules/chrome/tasks/arch.yml
+++ b/modules/chrome/tasks/arch.yml
@@ -31,11 +31,29 @@
     - /tmp/google-chrome.rpm
     - /tmp/chrome-extract
 
-- name: Patch Chrome desktop file to add --no-sandbox (required in containers)
+- name: Create Google Chrome wrapper script
+  ansible.builtin.copy:
+    dest: /usr/local/bin/google-chrome
+    mode: "0755"
+    content: |
+      #!/bin/bash
+      BIN=/opt/google/chrome/google-chrome
+
+      if ! pgrep -x google-chrome > /dev/null; then
+        rm -f "$HOME/.config/google-chrome/Singleton"*
+      fi
+
+      if grep -q 'Seccomp:.0' /proc/1/status; then
+        ${BIN} --no-first-run --password-store=basic "$@"
+      else
+        ${BIN} --no-first-run --password-store=basic --no-sandbox --test-type "$@"
+      fi
+
+- name: Patch Chrome desktop file to use wrapper
   ansible.builtin.replace:
     path: /usr/share/applications/google-chrome.desktop
-    regexp: '^(Exec=/usr/bin/google-chrome[^ ]*)(.*)'
-    replace: '\1 --no-sandbox\2'
+    regexp: '^(Exec=)[^ ]*(.*)'
+    replace: '\1/usr/local/bin/google-chrome\2'
 
 - name: Ensure Desktop directory exists
   ansible.builtin.file:

--- a/modules/chrome/tasks/arch.yml
+++ b/modules/chrome/tasks/arch.yml
@@ -31,6 +31,12 @@
     - /tmp/google-chrome.rpm
     - /tmp/chrome-extract
 
+- name: Patch Chrome desktop file to add --no-sandbox (required in containers)
+  ansible.builtin.replace:
+    path: /usr/share/applications/google-chrome.desktop
+    regexp: '^(Exec=/usr/bin/google-chrome[^ ]*)(.*)'
+    replace: '\1 --no-sandbox\2'
+
 - name: Ensure Desktop directory exists
   ansible.builtin.file:
     path: "{{ desktopus_home }}/Desktop"

--- a/modules/chrome/tasks/debian.yml
+++ b/modules/chrome/tasks/debian.yml
@@ -16,6 +16,12 @@
     state: present
     update_cache: true
 
+- name: Patch Chrome desktop file to add --no-sandbox (required in containers)
+  ansible.builtin.replace:
+    path: /usr/share/applications/google-chrome.desktop
+    regexp: '^(Exec=/usr/bin/google-chrome[^ ]*)(.*)'
+    replace: '\1 --no-sandbox\2'
+
 - name: Ensure Desktop directory exists
   ansible.builtin.file:
     path: "{{ desktopus_home }}/Desktop"

--- a/modules/chrome/tasks/debian.yml
+++ b/modules/chrome/tasks/debian.yml
@@ -1,12 +1,19 @@
 ---
+- name: Create keyrings directory
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: "0755"
+
 - name: Add Google Chrome signing key
-  ansible.builtin.apt_key:
+  ansible.builtin.get_url:
     url: https://dl.google.com/linux/linux_signing_key.pub
-    state: present
+    dest: /etc/apt/keyrings/google-chrome.asc
+    mode: "0644"
 
 - name: Add Google Chrome repository
   ansible.builtin.apt_repository:
-    repo: "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main"
+    repo: "deb [arch=amd64 signed-by=/etc/apt/keyrings/google-chrome.asc] http://dl.google.com/linux/chrome/deb/ stable main"
     state: present
     filename: google-chrome
 

--- a/modules/chrome/tasks/debian.yml
+++ b/modules/chrome/tasks/debian.yml
@@ -16,11 +16,29 @@
     state: present
     update_cache: true
 
-- name: Patch Chrome desktop file to add --no-sandbox (required in containers)
+- name: Create Google Chrome wrapper script
+  ansible.builtin.copy:
+    dest: /usr/local/bin/google-chrome
+    mode: "0755"
+    content: |
+      #!/bin/bash
+      BIN=/opt/google/chrome/google-chrome
+
+      if ! pgrep -x google-chrome > /dev/null; then
+        rm -f "$HOME/.config/google-chrome/Singleton"*
+      fi
+
+      if grep -q 'Seccomp:.0' /proc/1/status; then
+        ${BIN} --no-first-run --password-store=basic "$@"
+      else
+        ${BIN} --no-first-run --password-store=basic --no-sandbox --test-type "$@"
+      fi
+
+- name: Patch Chrome desktop file to use wrapper
   ansible.builtin.replace:
     path: /usr/share/applications/google-chrome.desktop
-    regexp: '^(Exec=/usr/bin/google-chrome[^ ]*)(.*)'
-    replace: '\1 --no-sandbox\2'
+    regexp: '^(Exec=)[^ ]*(.*)'
+    replace: '\1/usr/local/bin/google-chrome\2'
 
 - name: Ensure Desktop directory exists
   ansible.builtin.file:

--- a/modules/chrome/tasks/el.yml
+++ b/modules/chrome/tasks/el.yml
@@ -13,11 +13,29 @@
     name: "google-chrome-{{ chrome_channel | default('stable') }}"
     state: present
 
-- name: Patch Chrome desktop file to add --no-sandbox (required in containers)
+- name: Create Google Chrome wrapper script
+  ansible.builtin.copy:
+    dest: /usr/local/bin/google-chrome
+    mode: "0755"
+    content: |
+      #!/bin/bash
+      BIN=/opt/google/chrome/google-chrome
+
+      if ! pgrep -x google-chrome > /dev/null; then
+        rm -f "$HOME/.config/google-chrome/Singleton"*
+      fi
+
+      if grep -q 'Seccomp:.0' /proc/1/status; then
+        ${BIN} --no-first-run --password-store=basic "$@"
+      else
+        ${BIN} --no-first-run --password-store=basic --no-sandbox --test-type "$@"
+      fi
+
+- name: Patch Chrome desktop file to use wrapper
   ansible.builtin.replace:
     path: /usr/share/applications/google-chrome.desktop
-    regexp: '^(Exec=/usr/bin/google-chrome[^ ]*)(.*)'
-    replace: '\1 --no-sandbox\2'
+    regexp: '^(Exec=)[^ ]*(.*)'
+    replace: '\1/usr/local/bin/google-chrome\2'
 
 - name: Ensure Desktop directory exists
   ansible.builtin.file:

--- a/modules/chrome/tasks/el.yml
+++ b/modules/chrome/tasks/el.yml
@@ -13,6 +13,12 @@
     name: "google-chrome-{{ chrome_channel | default('stable') }}"
     state: present
 
+- name: Patch Chrome desktop file to add --no-sandbox (required in containers)
+  ansible.builtin.replace:
+    path: /usr/share/applications/google-chrome.desktop
+    regexp: '^(Exec=/usr/bin/google-chrome[^ ]*)(.*)'
+    replace: '\1 --no-sandbox\2'
+
 - name: Ensure Desktop directory exists
   ansible.builtin.file:
     path: "{{ desktopus_home }}/Desktop"

--- a/modules/chrome/tasks/fedora.yml
+++ b/modules/chrome/tasks/fedora.yml
@@ -13,11 +13,29 @@
     name: "google-chrome-{{ chrome_channel | default('stable') }}"
     state: present
 
-- name: Patch Chrome desktop file to add --no-sandbox (required in containers)
+- name: Create Google Chrome wrapper script
+  ansible.builtin.copy:
+    dest: /usr/local/bin/google-chrome
+    mode: "0755"
+    content: |
+      #!/bin/bash
+      BIN=/opt/google/chrome/google-chrome
+
+      if ! pgrep -x google-chrome > /dev/null; then
+        rm -f "$HOME/.config/google-chrome/Singleton"*
+      fi
+
+      if grep -q 'Seccomp:.0' /proc/1/status; then
+        ${BIN} --no-first-run --password-store=basic "$@"
+      else
+        ${BIN} --no-first-run --password-store=basic --no-sandbox --test-type "$@"
+      fi
+
+- name: Patch Chrome desktop file to use wrapper
   ansible.builtin.replace:
     path: /usr/share/applications/google-chrome.desktop
-    regexp: '^(Exec=/usr/bin/google-chrome[^ ]*)(.*)'
-    replace: '\1 --no-sandbox\2'
+    regexp: '^(Exec=)[^ ]*(.*)'
+    replace: '\1/usr/local/bin/google-chrome\2'
 
 - name: Ensure Desktop directory exists
   ansible.builtin.file:

--- a/modules/chrome/tasks/fedora.yml
+++ b/modules/chrome/tasks/fedora.yml
@@ -13,6 +13,12 @@
     name: "google-chrome-{{ chrome_channel | default('stable') }}"
     state: present
 
+- name: Patch Chrome desktop file to add --no-sandbox (required in containers)
+  ansible.builtin.replace:
+    path: /usr/share/applications/google-chrome.desktop
+    regexp: '^(Exec=/usr/bin/google-chrome[^ ]*)(.*)'
+    replace: '\1 --no-sandbox\2'
+
 - name: Ensure Desktop directory exists
   ansible.builtin.file:
     path: "{{ desktopus_home }}/Desktop"

--- a/modules/chrome/tasks/main.yml
+++ b/modules/chrome/tasks/main.yml
@@ -16,6 +16,12 @@
     state: present
     update_cache: true
 
+- name: Patch Chrome desktop file to add --no-sandbox (required in containers)
+  ansible.builtin.replace:
+    path: /usr/share/applications/google-chrome.desktop
+    regexp: '^(Exec=/usr/bin/google-chrome[^ ]*)(.*)'
+    replace: '\1 --no-sandbox\2'
+
 - name: Ensure Desktop directory exists
   ansible.builtin.file:
     path: "{{ desktopus_home }}/Desktop"

--- a/modules/chrome/tasks/main.yml
+++ b/modules/chrome/tasks/main.yml
@@ -1,12 +1,19 @@
 ---
+- name: Create keyrings directory
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: "0755"
+
 - name: Add Google Chrome signing key
-  ansible.builtin.apt_key:
+  ansible.builtin.get_url:
     url: https://dl.google.com/linux/linux_signing_key.pub
-    state: present
+    dest: /etc/apt/keyrings/google-chrome.asc
+    mode: "0644"
 
 - name: Add Google Chrome repository
   ansible.builtin.apt_repository:
-    repo: "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main"
+    repo: "deb [arch=amd64 signed-by=/etc/apt/keyrings/google-chrome.asc] http://dl.google.com/linux/chrome/deb/ stable main"
     state: present
     filename: google-chrome
 

--- a/modules/chrome/tasks/main.yml
+++ b/modules/chrome/tasks/main.yml
@@ -16,11 +16,29 @@
     state: present
     update_cache: true
 
-- name: Patch Chrome desktop file to add --no-sandbox (required in containers)
+- name: Create Google Chrome wrapper script
+  ansible.builtin.copy:
+    dest: /usr/local/bin/google-chrome
+    mode: "0755"
+    content: |
+      #!/bin/bash
+      BIN=/opt/google/chrome/google-chrome
+
+      if ! pgrep -x google-chrome > /dev/null; then
+        rm -f "$HOME/.config/google-chrome/Singleton"*
+      fi
+
+      if grep -q 'Seccomp:.0' /proc/1/status; then
+        ${BIN} --no-first-run --password-store=basic "$@"
+      else
+        ${BIN} --no-first-run --password-store=basic --no-sandbox --test-type "$@"
+      fi
+
+- name: Patch Chrome desktop file to use wrapper
   ansible.builtin.replace:
     path: /usr/share/applications/google-chrome.desktop
-    regexp: '^(Exec=/usr/bin/google-chrome[^ ]*)(.*)'
-    replace: '\1 --no-sandbox\2'
+    regexp: '^(Exec=)[^ ]*(.*)'
+    replace: '\1/usr/local/bin/google-chrome\2'
 
 - name: Ensure Desktop directory exists
   ansible.builtin.file:

--- a/modules/chrome/tasks/ubuntu.yml
+++ b/modules/chrome/tasks/ubuntu.yml
@@ -16,6 +16,12 @@
     state: present
     update_cache: true
 
+- name: Patch Chrome desktop file to add --no-sandbox (required in containers)
+  ansible.builtin.replace:
+    path: /usr/share/applications/google-chrome.desktop
+    regexp: '^(Exec=/usr/bin/google-chrome[^ ]*)(.*)'
+    replace: '\1 --no-sandbox\2'
+
 - name: Ensure Desktop directory exists
   ansible.builtin.file:
     path: "{{ desktopus_home }}/Desktop"

--- a/modules/chrome/tasks/ubuntu.yml
+++ b/modules/chrome/tasks/ubuntu.yml
@@ -1,12 +1,19 @@
 ---
+- name: Create keyrings directory
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: "0755"
+
 - name: Add Google Chrome signing key
-  ansible.builtin.apt_key:
+  ansible.builtin.get_url:
     url: https://dl.google.com/linux/linux_signing_key.pub
-    state: present
+    dest: /etc/apt/keyrings/google-chrome.asc
+    mode: "0644"
 
 - name: Add Google Chrome repository
   ansible.builtin.apt_repository:
-    repo: "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main"
+    repo: "deb [arch=amd64 signed-by=/etc/apt/keyrings/google-chrome.asc] http://dl.google.com/linux/chrome/deb/ stable main"
     state: present
     filename: google-chrome
 

--- a/modules/chrome/tasks/ubuntu.yml
+++ b/modules/chrome/tasks/ubuntu.yml
@@ -16,11 +16,29 @@
     state: present
     update_cache: true
 
-- name: Patch Chrome desktop file to add --no-sandbox (required in containers)
+- name: Create Google Chrome wrapper script
+  ansible.builtin.copy:
+    dest: /usr/local/bin/google-chrome
+    mode: "0755"
+    content: |
+      #!/bin/bash
+      BIN=/opt/google/chrome/google-chrome
+
+      if ! pgrep -x google-chrome > /dev/null; then
+        rm -f "$HOME/.config/google-chrome/Singleton"*
+      fi
+
+      if grep -q 'Seccomp:.0' /proc/1/status; then
+        ${BIN} --no-first-run --password-store=basic "$@"
+      else
+        ${BIN} --no-first-run --password-store=basic --no-sandbox --test-type "$@"
+      fi
+
+- name: Patch Chrome desktop file to use wrapper
   ansible.builtin.replace:
     path: /usr/share/applications/google-chrome.desktop
-    regexp: '^(Exec=/usr/bin/google-chrome[^ ]*)(.*)'
-    replace: '\1 --no-sandbox\2'
+    regexp: '^(Exec=)[^ ]*(.*)'
+    replace: '\1/usr/local/bin/google-chrome\2'
 
 - name: Ensure Desktop directory exists
   ansible.builtin.file:

--- a/modules/integration_test.go
+++ b/modules/integration_test.go
@@ -6,9 +6,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"testing"
 
+	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
 
 	"github.com/desktopus-org/desktopus/internal/build"
@@ -72,8 +74,55 @@ func TestBuildModule(t *testing.T) {
 					if buildLog {
 						t.Logf("Build output:\n%s", output.String())
 					}
+
+					for i, cmd := range mod.SmokeCmds(os) {
+						i, cmd := i, cmd
+						t.Run(fmt.Sprintf("smoke/%d", i), func(t *testing.T) {
+							runSmokeTest(t, ctx, docker, imageTag, cmd)
+						})
+					}
 				})
 			}
+		}
+	}
+}
+
+// runSmokeTest runs a one-shot container overriding the entrypoint with cmd,
+// waits for it to exit, and fails the test if the exit code is non-zero.
+func runSmokeTest(t *testing.T, ctx context.Context, docker *client.Client, imageTag string, cmd []string) {
+	t.Helper()
+
+	resp, err := docker.ContainerCreate(ctx, client.ContainerCreateOptions{
+		Config: &container.Config{
+			Image:      imageTag,
+			Entrypoint: cmd[:1],
+			Cmd:        cmd[1:],
+		},
+	})
+	if err != nil {
+		t.Fatalf("ContainerCreate: %v", err)
+	}
+	defer docker.ContainerRemove(ctx, resp.ID, client.ContainerRemoveOptions{Force: true}) //nolint:errcheck
+
+	if _, err := docker.ContainerStart(ctx, resp.ID, client.ContainerStartOptions{}); err != nil {
+		t.Fatalf("ContainerStart: %v", err)
+	}
+
+	result := docker.ContainerWait(ctx, resp.ID, client.ContainerWaitOptions{Condition: container.WaitConditionNotRunning})
+	select {
+	case err := <-result.Error:
+		t.Fatalf("ContainerWait: %v", err)
+	case status := <-result.Result:
+		if status.StatusCode != 0 {
+			logsResult, _ := docker.ContainerLogs(ctx, resp.ID, client.ContainerLogsOptions{
+				ShowStdout: true,
+				ShowStderr: true,
+			})
+			var buf bytes.Buffer
+			if logsResult != nil {
+				_, _ = io.Copy(&buf, logsResult)
+			}
+			t.Fatalf("smoke test exited %d:\n%s", status.StatusCode, buf.String())
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- **Wrapper script** (mirrors linuxserver/docker-webtop approach): instead of always disabling the sandbox, a wrapper at `/usr/local/bin/google-chrome` (or `/usr/local/bin/chromium` on Alpine) detects container privilege level via `/proc/1/status` — only adds `--no-sandbox --test-type` when seccomp is active. Also cleans up stale singleton lock files on start.
- **apt-key removed in Debian 13 (Trixie)**: switched to the modern `signed-by=` keyring approach, saving the key to `/etc/apt/keyrings/`. Applied to ubuntu and main preemptively since `apt-key` is deprecated there too.
- **Smoke test framework**: adds a `smoke_test` field to `module.yaml` — a list of commands run as one-shot containers after a successful build. For chrome: (0) wrapper binary launches, (1) the `Exec=` command from the `.desktop` file is executed, verifying the file was patched correctly.