### PR TITLE
feat: declarative contract tests in module.yaml

### DIFF
--- a/internal/module/types.go
+++ b/internal/module/types.go
@@ -20,7 +20,8 @@ type Module struct {
 	// OSTaskFiles maps OS names to true if tasks/<os>.yml exists
 	OSTaskFiles map[string]bool `yaml:"-"`
 
-	SmokeTest *SmokeTest `yaml:"smoke_test,omitempty"`
+	SmokeTest *SmokeTest   `yaml:"smoke_test,omitempty"`
+	Tests     *ModuleTests `yaml:"tests,omitempty"`
 }
 
 // Compatibility defines which OS/desktop/arch combos a module supports
@@ -28,6 +29,14 @@ type Compatibility struct {
 	OS      []string `yaml:"os,omitempty"`
 	Desktop []string `yaml:"desktop,omitempty"`
 	Arch    []string `yaml:"arch,omitempty"`
+}
+
+// ModuleTests defines declarative contract assertions evaluated by unit tests.
+type ModuleTests struct {
+	RequiredVars           []string `yaml:"required_vars,omitempty"`
+	RequiredSystemPackages []string `yaml:"required_system_packages,omitempty"`
+	ExcludedOS             []string `yaml:"excluded_os,omitempty"`
+	OSSpecificTaskFiles    bool     `yaml:"os_specific_task_files,omitempty"`
 }
 
 // SmokeTest defines commands to run inside a built image to verify the module works.

--- a/internal/module/types.go
+++ b/internal/module/types.go
@@ -20,8 +20,7 @@ type Module struct {
 	// OSTaskFiles maps OS names to true if tasks/<os>.yml exists
 	OSTaskFiles map[string]bool `yaml:"-"`
 
-	SmokeTest *SmokeTest   `yaml:"smoke_test,omitempty"`
-	Tests     *ModuleTests `yaml:"tests,omitempty"`
+	Tests *ModuleTests `yaml:"tests,omitempty"`
 }
 
 // Compatibility defines which OS/desktop/arch combos a module supports
@@ -31,12 +30,13 @@ type Compatibility struct {
 	Arch    []string `yaml:"arch,omitempty"`
 }
 
-// ModuleTests defines declarative contract assertions evaluated by unit tests.
+// ModuleTests groups all test declarations for a module.
 type ModuleTests struct {
-	RequiredVars           []string `yaml:"required_vars,omitempty"`
-	RequiredSystemPackages []string `yaml:"required_system_packages,omitempty"`
-	ExcludedOS             []string `yaml:"excluded_os,omitempty"`
-	OSSpecificTaskFiles    bool     `yaml:"os_specific_task_files,omitempty"`
+	RequiredVars           []string   `yaml:"required_vars,omitempty"`
+	RequiredSystemPackages []string   `yaml:"required_system_packages,omitempty"`
+	ExcludedOS             []string   `yaml:"excluded_os,omitempty"`
+	OSSpecificTaskFiles    bool       `yaml:"os_specific_task_files,omitempty"`
+	Smoke                  *SmokeTest `yaml:"smoke,omitempty"`
 }
 
 // SmokeTest defines commands to run inside a built image to verify the module works.
@@ -49,13 +49,14 @@ type SmokeTest struct {
 
 // SmokeCmds returns the smoke test commands for the given OS, or nil if none are defined.
 func (m *Module) SmokeCmds(targetOS string) [][]string {
-	if m.SmokeTest == nil {
+	if m.Tests == nil || m.Tests.Smoke == nil {
 		return nil
 	}
-	if cmds, ok := m.SmokeTest.OS[targetOS]; ok {
+	smoke := m.Tests.Smoke
+	if cmds, ok := smoke.OS[targetOS]; ok {
 		return cmds
 	}
-	return m.SmokeTest.Default
+	return smoke.Default
 }
 
 // Var defines a module variable

--- a/modules/chrome/module.yaml
+++ b/modules/chrome/module.yaml
@@ -20,8 +20,7 @@ tests:
   required_system_packages: [wget, gnupg]
   excluded_os: [alpine]
   os_specific_task_files: true
-
-smoke_test:
-  default:
-    - ["/usr/local/bin/google-chrome", "--version"]
-    - ["sh", "-c", "exec $(grep -m1 '^Exec=' /usr/share/applications/google-chrome.desktop | sed 's/^Exec=//;s/ %[A-Za-z]//g') --version"]
+  smoke:
+    default:
+      - ["/usr/local/bin/google-chrome", "--version"]
+      - ["sh", "-c", "exec $(grep -m1 '^Exec=' /usr/share/applications/google-chrome.desktop | sed 's/^Exec=//;s/ %[A-Za-z]//g') --version"]

--- a/modules/chrome/module.yaml
+++ b/modules/chrome/module.yaml
@@ -15,6 +15,12 @@ vars:
 
 system_packages: [wget, gnupg]
 
+tests:
+  required_vars: [chrome_channel]
+  required_system_packages: [wget, gnupg]
+  excluded_os: [alpine]
+  os_specific_task_files: true
+
 smoke_test:
   default:
     - ["/usr/local/bin/google-chrome", "--version"]

--- a/modules/modules_test.go
+++ b/modules/modules_test.go
@@ -105,21 +105,6 @@ func TestBuiltinModulesCompatibilityUsesValidValues(t *testing.T) {
 	}
 }
 
-func TestBuiltinModulesHaveOSTaskFiles(t *testing.T) {
-	reg := newRegistry(t)
-
-	for _, m := range reg.ListBuiltin() {
-		t.Run(m.Name, func(t *testing.T) {
-			for _, os := range m.Compatibility.OS {
-				taskFile := m.TaskFile(os)
-				expected := "tasks/" + os + ".yml"
-				if taskFile != expected {
-					t.Errorf("OS %q: expected %q, got %q (missing OS-specific task file)", os, expected, taskFile)
-				}
-			}
-		})
-	}
-}
 
 func TestBuiltinModulesTaskFileFallback(t *testing.T) {
 	reg := newRegistry(t)

--- a/modules/modules_test.go
+++ b/modules/modules_test.go
@@ -174,48 +174,38 @@ func TestBuiltinModulesTaskFilesAreValidYAML(t *testing.T) {
 	}
 }
 
-func TestChromeModule(t *testing.T) {
+func TestBuiltinModuleContracts(t *testing.T) {
 	reg := newRegistry(t)
-
-	mod, err := reg.Resolve("chrome", ".")
-	if err != nil {
-		t.Fatalf("Resolve chrome: %v", err)
-	}
-
-	// Has chrome_channel var
-	if _, ok := mod.Vars["chrome_channel"]; !ok {
-		t.Error("expected chrome_channel var")
-	}
-
-	// System packages include wget and gnupg
-	if !contains(mod.SystemPkgs, "wget") {
-		t.Errorf("expected wget in system_packages, got %v", mod.SystemPkgs)
-	}
-	if !contains(mod.SystemPkgs, "gnupg") {
-		t.Errorf("expected gnupg in system_packages, got %v", mod.SystemPkgs)
-	}
-
-	// Compatibility lists all supported OSes except Alpine (Chrome unavailable on musl)
-	expectedOSes := []string{"ubuntu", "debian", "fedora", "el", "arch"}
-	if len(mod.Compatibility.OS) != len(expectedOSes) {
-		t.Errorf("expected %d OSes, got %d: %v", len(expectedOSes), len(mod.Compatibility.OS), mod.Compatibility.OS)
-	}
-	for _, os := range expectedOSes {
-		if !contains(mod.Compatibility.OS, os) {
-			t.Errorf("missing OS %q in chrome compatibility", os)
+	for _, m := range reg.ListBuiltin() {
+		m := m
+		if m.Tests == nil {
+			continue
 		}
-	}
-	if contains(mod.Compatibility.OS, "alpine") {
-		t.Error("alpine should not be in chrome compatibility")
-	}
-
-	// Has 5 OS-specific task files (no alpine)
-	osCount := 0
-	for range mod.OSTaskFiles {
-		osCount++
-	}
-	if osCount != 5 {
-		t.Errorf("expected 5 OS task files, got %d: %v", osCount, mod.OSTaskFiles)
+		t.Run(m.Name, func(t *testing.T) {
+			tc := m.Tests
+			for _, v := range tc.RequiredVars {
+				if _, ok := m.Vars[v]; !ok {
+					t.Errorf("required var %q not found", v)
+				}
+			}
+			for _, pkg := range tc.RequiredSystemPackages {
+				if !contains(m.SystemPkgs, pkg) {
+					t.Errorf("required system_package %q not found", pkg)
+				}
+			}
+			for _, os := range tc.ExcludedOS {
+				if contains(m.Compatibility.OS, os) {
+					t.Errorf("OS %q should be excluded from compatibility", os)
+				}
+			}
+			if tc.OSSpecificTaskFiles {
+				for _, os := range m.Compatibility.OS {
+					if !m.OSTaskFiles[os] {
+						t.Errorf("OS %q has no OS-specific task file", os)
+					}
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds a `tests:` block to `module.yaml` for declaring per-module invariants (`required_vars`, `required_system_packages`, `excluded_os`, `os_specific_task_files`, `smoke`)
- Nests `smoke_test` inside `tests:` as `tests.smoke` — one unified section for all test declarations
- Replaces the hardcoded `TestChromeModule` with a dynamic `TestBuiltinModuleContracts` loop that enforces whatever each module declares
- Drops `TestBuiltinModulesHaveOSTaskFiles`, which unconditionally required OS-specific task files for all modules — now opt-in via `os_specific_task_files: true`

Adding contract tests for a new module requires only a `tests:` block in its `module.yaml` — no Go changes needed. Modules with no `tests:` block pass all tests unchanged.