### PR TITLE
refactor: move module tests to module_test.yaml

### DIFF
--- a/internal/module/loader.go
+++ b/internal/module/loader.go
@@ -39,8 +39,23 @@ func LoadFromFS(fsys fs.FS, dir string) (*Module, error) {
 	}
 
 	mod.OSTaskFiles = discoverOSTaskFiles(fsys, dir)
+	mod.Tests = loadModuleTests(fsys, dir)
 
 	return &mod, nil
+}
+
+// loadModuleTests optionally loads module_test.yaml from the module directory.
+// Returns nil if the file does not exist or cannot be parsed.
+func loadModuleTests(fsys fs.FS, dir string) *ModuleTests {
+	data, err := fs.ReadFile(fsys, dir+"/module_test.yaml")
+	if err != nil {
+		return nil
+	}
+	var tests ModuleTests
+	if err := yaml.Unmarshal(data, &tests); err != nil {
+		return nil
+	}
+	return &tests
 }
 
 // discoverOSTaskFiles scans the tasks/ directory for OS-specific task files.

--- a/modules/chrome/module.yaml
+++ b/modules/chrome/module.yaml
@@ -14,13 +14,3 @@ vars:
     description: "Chrome release channel (stable, beta, unstable)"
 
 system_packages: [wget, gnupg]
-
-tests:
-  required_vars: [chrome_channel]
-  required_system_packages: [wget, gnupg]
-  excluded_os: [alpine]
-  os_specific_task_files: true
-  smoke:
-    default:
-      - ["/usr/local/bin/google-chrome", "--version"]
-      - ["sh", "-c", "exec $(grep -m1 '^Exec=' /usr/share/applications/google-chrome.desktop | sed 's/^Exec=//;s/ %[A-Za-z]//g') --version"]

--- a/modules/chrome/module_test.yaml
+++ b/modules/chrome/module_test.yaml
@@ -1,0 +1,8 @@
+required_vars: [chrome_channel]
+required_system_packages: [wget, gnupg]
+excluded_os: [alpine]
+os_specific_task_files: true
+smoke:
+  default:
+    - ["/usr/local/bin/google-chrome", "--version"]
+    - ["sh", "-c", "exec $(grep -m1 '^Exec=' /usr/share/applications/google-chrome.desktop | sed 's/^Exec=//;s/ %[A-Za-z]//g') --version"]


### PR DESCRIPTION
## Summary

- Moves test declarations (contract assertions and smoke commands) out of `module.yaml` into an optional `module_test.yaml` alongside it
- `module.yaml` stays focused on runtime config — no test metadata mixed in
- The loader silently skips modules without `module_test.yaml`, so modules with no test declarations need no changes
- `module_test.yaml` root maps directly to `ModuleTests` — no wrapping key needed