### PR TITLE
feat: configurable user and home directory in desktopus.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,13 +84,12 @@ env:
 
 postrun:
   - name: configure-git
-    runas: abc
     script: |
       git config --global user.name "${GIT_USER_NAME}"
       git config --global user.email "${GIT_USER_EMAIL}"
 
 files:
-  - path: /config/.config/settings.json
+  - path: /home/desktopus/.config/settings.json
     content: '{"fontSize": 14}'
     mode: "0644"
 
@@ -100,7 +99,7 @@ runtime:
   ports:
     - "3000:3000"
   volumes:
-    - ~/projects:/config/projects
+    - ~/projects:/home/desktopus/projects
   gpu: false
   memory: 8g
   cpus: 4

--- a/internal/build/ansible.go
+++ b/internal/build/ansible.go
@@ -18,10 +18,12 @@ type moduleEntry struct {
 
 type playbookData struct {
 	Modules []moduleEntry
+	User    string
+	Home    string
 }
 
 // generatePlaybook renders the Ansible playbook from resolved modules
-func generatePlaybook(tmpl *template.Template, modules []*module.Module, varsOverrides []map[string]interface{}, targetOS string) ([]byte, error) {
+func generatePlaybook(tmpl *template.Template, modules []*module.Module, varsOverrides []map[string]interface{}, targetOS, desktopusUser, desktopusHome string) ([]byte, error) {
 	entries := make([]moduleEntry, len(modules))
 	for i, mod := range modules {
 		vars := make(map[string]interface{})
@@ -52,7 +54,7 @@ func generatePlaybook(tmpl *template.Template, modules []*module.Module, varsOve
 	}
 
 	var buf bytes.Buffer
-	if err := tmpl.Execute(&buf, playbookData{Modules: entries}); err != nil {
+	if err := tmpl.Execute(&buf, playbookData{Modules: entries, User: desktopusUser, Home: desktopusHome}); err != nil {
 		return nil, fmt.Errorf("rendering playbook: %w", err)
 	}
 	return buf.Bytes(), nil

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -426,7 +426,7 @@ func TestGeneratePlaybook(t *testing.T) {
 		{"chrome_channel": "beta"},
 	}
 
-	result, err := generatePlaybook(tmpl, modules, overrides, "ubuntu")
+	result, err := generatePlaybook(tmpl, modules, overrides, "ubuntu", "desktopus", "/home/desktopus")
 	if err != nil {
 		t.Fatalf("generatePlaybook: %v", err)
 	}
@@ -462,7 +462,7 @@ func TestGeneratePlaybookDefaults(t *testing.T) {
 	}
 
 	// No overrides
-	result, err := generatePlaybook(tmpl, modules, nil, "ubuntu")
+	result, err := generatePlaybook(tmpl, modules, nil, "ubuntu", "desktopus", "/home/desktopus")
 	if err != nil {
 		t.Fatalf("generatePlaybook: %v", err)
 	}
@@ -492,7 +492,7 @@ func TestGeneratePlaybookOSSpecificTaskFile(t *testing.T) {
 		},
 	}
 
-	result, err := generatePlaybook(tmpl, modules, nil, "ubuntu")
+	result, err := generatePlaybook(tmpl, modules, nil, "ubuntu", "desktopus", "/home/desktopus")
 	if err != nil {
 		t.Fatalf("generatePlaybook: %v", err)
 	}
@@ -525,7 +525,7 @@ func TestGeneratePlaybookOSFallback(t *testing.T) {
 	}
 
 	// Building for fedora, but chrome only has ubuntu-specific tasks
-	result, err := generatePlaybook(tmpl, modules, nil, "fedora")
+	result, err := generatePlaybook(tmpl, modules, nil, "fedora", "desktopus", "/home/desktopus")
 	if err != nil {
 		t.Fatalf("generatePlaybook: %v", err)
 	}
@@ -620,9 +620,9 @@ func TestAddPostRunScriptsDefaultRunAs(t *testing.T) {
 	}
 
 	data, _ := io.ReadAll(tr)
-	// Default should be "abc"
-	if !strings.Contains(string(data), "s6-setuidgid abc") {
-		t.Errorf("default runas should be abc, script: %s", string(data))
+	// Default should be "desktopus" (effective user when no user is set)
+	if !strings.Contains(string(data), "s6-setuidgid desktopus") {
+		t.Errorf("default runas should be desktopus, script: %s", string(data))
 	}
 	if header.Mode != 0755 {
 		t.Errorf("expected mode 0755, got %o", header.Mode)
@@ -831,6 +831,196 @@ func TestStreamBuildOutputPullProgress(t *testing.T) {
 	// Regular stream events must still appear
 	if !strings.Contains(got, "Step 1/9") {
 		t.Error("missing stream output")
+	}
+}
+
+// --- generateDockerfile user creation ---
+
+func TestGenerateDockerfileDefaultUser(t *testing.T) {
+	tmplFuncs := templateFuncs()
+	tmpl, err := template.New("Dockerfile.tmpl").Funcs(tmplFuncs).ParseFS(templatesFS, "templates/Dockerfile.tmpl")
+	if err != nil {
+		t.Fatalf("parse template: %v", err)
+	}
+
+	cfg := &config.DesktopConfig{
+		Name: "test",
+		Base: config.BaseSpec{OS: "ubuntu", Desktop: "xfce"},
+		// User omitted → creates "desktopus" with home "/home/desktopus"
+	}
+
+	result, err := generateDockerfile(tmpl, cfg, nil, 0)
+	if err != nil {
+		t.Fatalf("generateDockerfile: %v", err)
+	}
+
+	dockerfile := string(result)
+	if !strings.Contains(dockerfile, "RUN useradd -m -d /home/desktopus -s /bin/bash desktopus") {
+		t.Errorf("expected useradd for default user, got:\n%s", dockerfile)
+	}
+}
+
+func TestGenerateDockerfileAbcUser(t *testing.T) {
+	tmplFuncs := templateFuncs()
+	tmpl, err := template.New("Dockerfile.tmpl").Funcs(tmplFuncs).ParseFS(templatesFS, "templates/Dockerfile.tmpl")
+	if err != nil {
+		t.Fatalf("parse template: %v", err)
+	}
+
+	cfg := &config.DesktopConfig{
+		Name: "test",
+		Base: config.BaseSpec{OS: "ubuntu", Desktop: "xfce"},
+		User: "abc",
+	}
+
+	result, err := generateDockerfile(tmpl, cfg, nil, 0)
+	if err != nil {
+		t.Fatalf("generateDockerfile: %v", err)
+	}
+
+	if strings.Contains(string(result), "RUN useradd") {
+		t.Error("abc user should not emit RUN useradd (built-in user)")
+	}
+}
+
+func TestGenerateDockerfileCustomUser(t *testing.T) {
+	tmplFuncs := templateFuncs()
+	tmpl, err := template.New("Dockerfile.tmpl").Funcs(tmplFuncs).ParseFS(templatesFS, "templates/Dockerfile.tmpl")
+	if err != nil {
+		t.Fatalf("parse template: %v", err)
+	}
+
+	cfg := &config.DesktopConfig{
+		Name: "test",
+		Base: config.BaseSpec{OS: "ubuntu", Desktop: "xfce"},
+		User: "carlos",
+	}
+
+	result, err := generateDockerfile(tmpl, cfg, nil, 0)
+	if err != nil {
+		t.Fatalf("generateDockerfile: %v", err)
+	}
+
+	dockerfile := string(result)
+	if !strings.Contains(dockerfile, "RUN useradd -m -d /home/carlos -s /bin/bash carlos") {
+		t.Errorf("expected useradd for custom user, got:\n%s", dockerfile)
+	}
+}
+
+// --- generatePlaybook user/home ---
+
+func TestGeneratePlaybookDefaultUser(t *testing.T) {
+	tmpl, err := template.New("playbook.yml.tmpl").ParseFS(templatesFS, "templates/playbook.yml.tmpl")
+	if err != nil {
+		t.Fatalf("parse template: %v", err)
+	}
+
+	result, err := generatePlaybook(tmpl, nil, nil, "ubuntu", "desktopus", "/home/desktopus")
+	if err != nil {
+		t.Fatalf("generatePlaybook: %v", err)
+	}
+
+	playbook := string(result)
+	if !strings.Contains(playbook, "desktopus_user: desktopus") {
+		t.Errorf("expected desktopus_user: desktopus, got:\n%s", playbook)
+	}
+	if !strings.Contains(playbook, "desktopus_home: /home/desktopus") {
+		t.Errorf("expected desktopus_home: /home/desktopus, got:\n%s", playbook)
+	}
+}
+
+func TestGeneratePlaybookCustomUser(t *testing.T) {
+	tmpl, err := template.New("playbook.yml.tmpl").ParseFS(templatesFS, "templates/playbook.yml.tmpl")
+	if err != nil {
+		t.Fatalf("parse template: %v", err)
+	}
+
+	result, err := generatePlaybook(tmpl, nil, nil, "ubuntu", "carlos", "/home/carlos")
+	if err != nil {
+		t.Fatalf("generatePlaybook: %v", err)
+	}
+
+	playbook := string(result)
+	if !strings.Contains(playbook, "desktopus_user: carlos") {
+		t.Errorf("expected desktopus_user: carlos, got:\n%s", playbook)
+	}
+	if !strings.Contains(playbook, "desktopus_home: /home/carlos") {
+		t.Errorf("expected desktopus_home: /home/carlos, got:\n%s", playbook)
+	}
+}
+
+// --- addPostRunScripts default user ---
+
+func TestAddPostRunScriptsDefaultUser(t *testing.T) {
+	bctx := NewBuildContext()
+	cfg := &config.DesktopConfig{
+		// User omitted → effective user is "desktopus"
+		PostRun: []config.PostRunScript{
+			{Name: "test", Script: "echo hi"},
+		},
+	}
+
+	if err := addPostRunScripts(bctx, cfg); err != nil {
+		t.Fatalf("addPostRunScripts: %v", err)
+	}
+
+	reader, err := bctx.Reader()
+	if err != nil {
+		t.Fatalf("Reader: %v", err)
+	}
+
+	tr := tar.NewReader(reader)
+	_, err = tr.Next()
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+
+	data, _ := io.ReadAll(tr)
+	if !strings.Contains(string(data), "s6-setuidgid desktopus") {
+		t.Errorf("default runas should be desktopus, got:\n%s", string(data))
+	}
+}
+
+// --- addRuntimeFiles default user ---
+
+func TestAddRuntimeFilesDefaultUser(t *testing.T) {
+	bctx := NewBuildContext()
+	cfg := &config.DesktopConfig{
+		// User omitted → effective user is "desktopus"
+		Files: []config.FileSpec{
+			{Path: "/home/desktopus/.bashrc", Content: "# bashrc"},
+		},
+	}
+
+	if err := addRuntimeFiles(bctx, cfg); err != nil {
+		t.Fatalf("addRuntimeFiles: %v", err)
+	}
+
+	reader, err := bctx.Reader()
+	if err != nil {
+		t.Fatalf("Reader: %v", err)
+	}
+
+	tr := tar.NewReader(reader)
+	files := make(map[string]string)
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Next: %v", err)
+		}
+		data, _ := io.ReadAll(tr)
+		files[header.Name] = string(data)
+	}
+
+	script, ok := files["99-desktopus-files.sh"]
+	if !ok {
+		t.Fatal("missing 99-desktopus-files.sh")
+	}
+	if !strings.Contains(script, "chown desktopus:desktopus") {
+		t.Errorf("provisioner should use chown desktopus:desktopus, got:\n%s", script)
 	}
 }
 

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -858,11 +858,8 @@ func TestGenerateDockerfileDefaultUser(t *testing.T) {
 	if !strings.Contains(dockerfile, "RUN useradd -m -d /home/desktopus -s /bin/bash desktopus") {
 		t.Errorf("expected useradd for default user, got:\n%s", dockerfile)
 	}
-	if !strings.Contains(dockerfile, "s6-setuidgid desktopus") {
-		t.Errorf("expected sed patch for s6-setuidgid, got:\n%s", dockerfile)
-	}
-	if !strings.Contains(dockerfile, "xdg-runtime-desktopus") {
-		t.Errorf("expected sed patch for xdg-runtime dir, got:\n%s", dockerfile)
+	if !strings.Contains(dockerfile, `s/\babc\b/desktopus/g`) {
+		t.Errorf("expected word-boundary sed patch for desktopus, got:\n%s", dockerfile)
 	}
 }
 
@@ -888,7 +885,7 @@ func TestGenerateDockerfileAbcUser(t *testing.T) {
 	if strings.Contains(dockerfile, "RUN useradd") {
 		t.Error("abc user should not emit RUN useradd (built-in user)")
 	}
-	if strings.Contains(dockerfile, "s6-setuidgid desktopus") || strings.Contains(dockerfile, "sed -i") {
+	if strings.Contains(dockerfile, "sed -i") {
 		t.Error("abc user should not emit s6 patching")
 	}
 }
@@ -915,11 +912,8 @@ func TestGenerateDockerfileCustomUser(t *testing.T) {
 	if !strings.Contains(dockerfile, "RUN useradd -m -d /home/carlos -s /bin/bash carlos") {
 		t.Errorf("expected useradd for custom user, got:\n%s", dockerfile)
 	}
-	if !strings.Contains(dockerfile, "s6-setuidgid carlos") {
-		t.Errorf("expected sed patch for s6-setuidgid carlos, got:\n%s", dockerfile)
-	}
-	if !strings.Contains(dockerfile, "xdg-runtime-carlos") {
-		t.Errorf("expected sed patch for xdg-runtime dir, got:\n%s", dockerfile)
+	if !strings.Contains(dockerfile, `s/\babc\b/carlos/g`) {
+		t.Errorf("expected word-boundary sed patch for carlos, got:\n%s", dockerfile)
 	}
 }
 

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -858,6 +858,9 @@ func TestGenerateDockerfileDefaultUser(t *testing.T) {
 	if !strings.Contains(dockerfile, "RUN useradd -m -d /home/desktopus -s /bin/bash desktopus") {
 		t.Errorf("expected useradd for default user, got:\n%s", dockerfile)
 	}
+	if !strings.Contains(dockerfile, "ENV HOME=/home/desktopus") {
+		t.Errorf("expected ENV HOME override for default user, got:\n%s", dockerfile)
+	}
 	if !strings.Contains(dockerfile, `s/\babc\b/desktopus/g`) {
 		t.Errorf("expected word-boundary sed patch for desktopus, got:\n%s", dockerfile)
 	}
@@ -885,6 +888,9 @@ func TestGenerateDockerfileAbcUser(t *testing.T) {
 	if strings.Contains(dockerfile, "RUN useradd") {
 		t.Error("abc user should not emit RUN useradd (built-in user)")
 	}
+	if strings.Contains(dockerfile, "ENV HOME") {
+		t.Error("abc user should not override ENV HOME (keep base image /config)")
+	}
 	if strings.Contains(dockerfile, "sed -i") {
 		t.Error("abc user should not emit s6 patching")
 	}
@@ -911,6 +917,9 @@ func TestGenerateDockerfileCustomUser(t *testing.T) {
 	dockerfile := string(result)
 	if !strings.Contains(dockerfile, "RUN useradd -m -d /home/carlos -s /bin/bash carlos") {
 		t.Errorf("expected useradd for custom user, got:\n%s", dockerfile)
+	}
+	if !strings.Contains(dockerfile, "ENV HOME=/home/carlos") {
+		t.Errorf("expected ENV HOME override for custom user, got:\n%s", dockerfile)
 	}
 	if !strings.Contains(dockerfile, `s/\babc\b/carlos/g`) {
 		t.Errorf("expected word-boundary sed patch for carlos, got:\n%s", dockerfile)

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -183,9 +183,9 @@ func TestGenerateDockerfile(t *testing.T) {
 	if !strings.Contains(dockerfile, `org.desktopus.name="test-desktop"`) {
 		t.Error("missing name label")
 	}
-	// No post-run scripts, so should NOT have the section
-	if strings.Contains(dockerfile, "custom-cont-init.d") {
-		t.Error("should not have post-run section without post-run scripts")
+	// No post-run scripts, so should NOT have the COPY postrun/ section
+	if strings.Contains(dockerfile, "COPY postrun/") {
+		t.Error("should not have post-run COPY section without post-run scripts")
 	}
 	// Ubuntu should use apt-get and python3-apt
 	if !strings.Contains(dockerfile, "apt-get") {
@@ -864,6 +864,9 @@ func TestGenerateDockerfileDefaultUser(t *testing.T) {
 	if !strings.Contains(dockerfile, `s/\babc\b/desktopus/g`) {
 		t.Errorf("expected word-boundary sed patch for desktopus, got:\n%s", dockerfile)
 	}
+	if !strings.Contains(dockerfile, "01-desktopus-home.sh") {
+		t.Errorf("expected home ownership fix script, got:\n%s", dockerfile)
+	}
 }
 
 func TestGenerateDockerfileAbcUser(t *testing.T) {
@@ -893,6 +896,9 @@ func TestGenerateDockerfileAbcUser(t *testing.T) {
 	}
 	if strings.Contains(dockerfile, "sed -i") {
 		t.Error("abc user should not emit s6 patching")
+	}
+	if strings.Contains(dockerfile, "01-desktopus-home.sh") {
+		t.Error("abc user should not emit home ownership fix script")
 	}
 }
 

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -858,6 +858,12 @@ func TestGenerateDockerfileDefaultUser(t *testing.T) {
 	if !strings.Contains(dockerfile, "RUN useradd -m -d /home/desktopus -s /bin/bash desktopus") {
 		t.Errorf("expected useradd for default user, got:\n%s", dockerfile)
 	}
+	if !strings.Contains(dockerfile, "s6-setuidgid desktopus") {
+		t.Errorf("expected sed patch for s6-setuidgid, got:\n%s", dockerfile)
+	}
+	if !strings.Contains(dockerfile, "xdg-runtime-desktopus") {
+		t.Errorf("expected sed patch for xdg-runtime dir, got:\n%s", dockerfile)
+	}
 }
 
 func TestGenerateDockerfileAbcUser(t *testing.T) {
@@ -878,8 +884,12 @@ func TestGenerateDockerfileAbcUser(t *testing.T) {
 		t.Fatalf("generateDockerfile: %v", err)
 	}
 
-	if strings.Contains(string(result), "RUN useradd") {
+	dockerfile := string(result)
+	if strings.Contains(dockerfile, "RUN useradd") {
 		t.Error("abc user should not emit RUN useradd (built-in user)")
+	}
+	if strings.Contains(dockerfile, "s6-setuidgid desktopus") || strings.Contains(dockerfile, "sed -i") {
+		t.Error("abc user should not emit s6 patching")
 	}
 }
 
@@ -904,6 +914,12 @@ func TestGenerateDockerfileCustomUser(t *testing.T) {
 	dockerfile := string(result)
 	if !strings.Contains(dockerfile, "RUN useradd -m -d /home/carlos -s /bin/bash carlos") {
 		t.Errorf("expected useradd for custom user, got:\n%s", dockerfile)
+	}
+	if !strings.Contains(dockerfile, "s6-setuidgid carlos") {
+		t.Errorf("expected sed patch for s6-setuidgid carlos, got:\n%s", dockerfile)
+	}
+	if !strings.Contains(dockerfile, "xdg-runtime-carlos") {
+		t.Errorf("expected sed patch for xdg-runtime dir, got:\n%s", dockerfile)
 	}
 }
 

--- a/internal/build/dockerfile.go
+++ b/internal/build/dockerfile.go
@@ -19,6 +19,9 @@ type dockerfileData struct {
 	AnsibleVerbosity int
 	PostRunScripts   bool
 	RuntimeFiles     bool
+	CreateUser       bool
+	User             string
+	Home             string
 }
 
 // generateDockerfile renders the Dockerfile from the template and config
@@ -44,6 +47,9 @@ func generateDockerfile(tmpl *template.Template, cfg *config.DesktopConfig, modu
 		AnsibleVerbosity: ansibleVerbosity,
 		PostRunScripts:   len(cfg.PostRun) > 0,
 		RuntimeFiles:     len(cfg.Files) > 0,
+		CreateUser:       cfg.EffectiveUser() != "abc",
+		User:             cfg.EffectiveUser(),
+		Home:             cfg.EffectiveHome(),
 	}
 
 	var buf bytes.Buffer

--- a/internal/build/pipeline.go
+++ b/internal/build/pipeline.go
@@ -70,7 +70,7 @@ func (p *Pipeline) Build(ctx context.Context, cfg *config.DesktopConfig, configD
 	if err != nil {
 		return err
 	}
-	playbook, err := generatePlaybook(playbookTmpl, modules, varsOverrides, cfg.Base.OS)
+	playbook, err := generatePlaybook(playbookTmpl, modules, varsOverrides, cfg.Base.OS, cfg.EffectiveUser(), cfg.EffectiveHome())
 	if err != nil {
 		return err
 	}
@@ -201,7 +201,7 @@ func addPostRunScripts(bctx *BuildContext, cfg *config.DesktopConfig) error {
 	for i, pr := range cfg.PostRun {
 		runas := pr.RunAs
 		if runas == "" {
-			runas = "abc"
+			runas = cfg.EffectiveUser()
 		}
 
 		var script string
@@ -242,7 +242,8 @@ func addRuntimeFiles(bctx *BuildContext, cfg *config.DesktopConfig) error {
 		}
 		script += fmt.Sprintf("mkdir -p \"$(dirname '%s')\"\n", f.Path)
 		script += fmt.Sprintf("envsubst < '/tmp/desktopus-runtime-files%s' > '%s'\n", f.Path, f.Path)
-		script += fmt.Sprintf("chown abc:abc '%s'\n", f.Path)
+		user := cfg.EffectiveUser()
+		script += fmt.Sprintf("chown %s:%s '%s'\n", user, user, f.Path)
 		script += fmt.Sprintf("chmod %s '%s'\n\n", mode, f.Path)
 	}
 

--- a/internal/build/templates/Dockerfile.tmpl
+++ b/internal/build/templates/Dockerfile.tmpl
@@ -2,6 +2,13 @@
 # Desktop: {{ .Name }}
 
 FROM {{ .BaseImage }}
+{{- if .CreateUser }}
+
+# ============================================
+# Create desktop user
+# ============================================
+RUN useradd -m -d {{ .Home }} -s /bin/bash {{ .User }}
+{{- end }}
 
 # ============================================
 # Ansible provisioning

--- a/internal/build/templates/Dockerfile.tmpl
+++ b/internal/build/templates/Dockerfile.tmpl
@@ -11,20 +11,15 @@ RUN useradd -m -d {{ .Home }} -s /bin/bash {{ .User }}
 
 # ============================================
 # Patch s6 services and desktop session launchers
-# to run as {{ .User }} instead of the built-in abc user
+# to run as {{ .User }} instead of the built-in abc user.
+# Uses word-boundary replacement so every reference is covered:
+# s6-setuidgid, chown/lsiown ownership, pgrep -u, id -u/G,
+# group ownership (root:abc), xdg-runtime paths, etc.
 # ============================================
 RUN find /etc/s6-overlay/s6-rc.d/ -type f -name "run" \
-      -exec sed -i \
-        -e 's/s6-setuidgid abc/s6-setuidgid {{ .User }}/g' \
-        -e 's/chown abc:abc/chown {{ .User }}:{{ .User }}/g' \
-        -e 's/lsiown abc:abc/lsiown {{ .User }}:{{ .User }}/g' \
-        -e 's|/tmp/xdg-runtime-abc|/tmp/xdg-runtime-{{ .User }}|g' \
-      {} + && \
+      -exec sed -i 's/\babc\b/{{ .User }}/g' {} + && \
     find /defaults/ -maxdepth 1 -name "startwm*.sh" \
-      -exec sed -i \
-        -e 's/chown abc:abc/chown {{ .User }}:{{ .User }}/g' \
-        -e 's|/tmp/xdg-runtime-abc|/tmp/xdg-runtime-{{ .User }}|g' \
-      {} +
+      -exec sed -i 's/\babc\b/{{ .User }}/g' {} +
 {{- end }}
 
 # ============================================

--- a/internal/build/templates/Dockerfile.tmpl
+++ b/internal/build/templates/Dockerfile.tmpl
@@ -8,6 +8,7 @@ FROM {{ .BaseImage }}
 # Create desktop user
 # ============================================
 RUN useradd -m -d {{ .Home }} -s /bin/bash {{ .User }}
+ENV HOME={{ .Home }}
 
 # ============================================
 # Patch s6 services and desktop session launchers

--- a/internal/build/templates/Dockerfile.tmpl
+++ b/internal/build/templates/Dockerfile.tmpl
@@ -21,6 +21,18 @@ RUN find /etc/s6-overlay/s6-rc.d/ -type f -name "run" \
       -exec sed -i 's/\babc\b/{{ .User }}/g' {} + && \
     find /defaults/ -maxdepth 1 -name "startwm*.sh" \
       -exec sed -i 's/\babc\b/{{ .User }}/g' {} +
+
+# ============================================
+# Fix home directory ownership after UID/GID remapping.
+# init-adduser remaps the UID/GID of {{ .User }} at container
+# startup but does not chown the home directory. This cont-init
+# script runs after init-adduser and before any services to
+# ensure {{ .Home }} is owned by the correct UID/GID.
+# ============================================
+RUN mkdir -p /custom-cont-init.d && \
+    printf '#!/usr/bin/with-contenv bash\nmkdir -p {{ .Home }}\nchown -R {{ .User }}:{{ .User }} {{ .Home }}\n' \
+      > /custom-cont-init.d/01-desktopus-home.sh && \
+    chmod +x /custom-cont-init.d/01-desktopus-home.sh
 {{- end }}
 
 # ============================================

--- a/internal/build/templates/Dockerfile.tmpl
+++ b/internal/build/templates/Dockerfile.tmpl
@@ -8,6 +8,23 @@ FROM {{ .BaseImage }}
 # Create desktop user
 # ============================================
 RUN useradd -m -d {{ .Home }} -s /bin/bash {{ .User }}
+
+# ============================================
+# Patch s6 services and desktop session launchers
+# to run as {{ .User }} instead of the built-in abc user
+# ============================================
+RUN find /etc/s6-overlay/s6-rc.d/ -type f -name "run" \
+      -exec sed -i \
+        -e 's/s6-setuidgid abc/s6-setuidgid {{ .User }}/g' \
+        -e 's/chown abc:abc/chown {{ .User }}:{{ .User }}/g' \
+        -e 's/lsiown abc:abc/lsiown {{ .User }}:{{ .User }}/g' \
+        -e 's|/tmp/xdg-runtime-abc|/tmp/xdg-runtime-{{ .User }}|g' \
+      {} + && \
+    find /defaults/ -maxdepth 1 -name "startwm*.sh" \
+      -exec sed -i \
+        -e 's/chown abc:abc/chown {{ .User }}:{{ .User }}/g' \
+        -e 's|/tmp/xdg-runtime-abc|/tmp/xdg-runtime-{{ .User }}|g' \
+      {} +
 {{- end }}
 
 # ============================================

--- a/internal/build/templates/playbook.yml.tmpl
+++ b/internal/build/templates/playbook.yml.tmpl
@@ -2,8 +2,8 @@
 - hosts: localhost
   become: true
   vars:
-    desktopus_user: abc
-    desktopus_home: /config
+    desktopus_user: {{ .User }}
+    desktopus_home: {{ .Home }}
 {{ range .Modules }}
   # --- Module: {{ .Name }} ---
 {{ range $k, $v := .Vars }}    {{ $k }}: {{ $v }}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -292,7 +292,8 @@ func TestValidateDesktopPostRunInvalidRunAs(t *testing.T) {
 }
 
 func TestValidateDesktopPostRunValidRunAs(t *testing.T) {
-	for _, runas := range []string{"", "root", "abc"} {
+	// Default user is "desktopus" when no user is set
+	for _, runas := range []string{"", "root", "desktopus"} {
 		cfg := &DesktopConfig{
 			Name: "test",
 			Base: BaseSpec{OS: "ubuntu", Desktop: "xfce"},
@@ -303,6 +304,18 @@ func TestValidateDesktopPostRunValidRunAs(t *testing.T) {
 		if err := ValidateDesktop(cfg); err != nil {
 			t.Errorf("runas %q should be valid: %v", runas, err)
 		}
+	}
+	// Custom user: runas must match the configured user
+	cfg := &DesktopConfig{
+		Name: "test",
+		Base: BaseSpec{OS: "ubuntu", Desktop: "xfce"},
+		User: "carlos",
+		PostRun: []PostRunScript{
+			{Name: "setup", Script: "echo hi", RunAs: "carlos"},
+		},
+	}
+	if err := ValidateDesktop(cfg); err != nil {
+		t.Errorf("runas 'carlos' should be valid for user 'carlos': %v", err)
 	}
 }
 
@@ -523,6 +536,91 @@ server:
 	}
 	if cfg.Server.Port != 9999 {
 		t.Errorf("expected port 9999, got %d", cfg.Server.Port)
+	}
+}
+
+// --- Custom user validation ---
+
+func TestValidateDesktopCustomUser(t *testing.T) {
+	for _, user := range []string{"carlos", "my_user", "x"} {
+		cfg := &DesktopConfig{
+			Name: "test",
+			Base: BaseSpec{OS: "ubuntu", Desktop: "xfce"},
+			User: user,
+		}
+		if err := ValidateDesktop(cfg); err != nil {
+			t.Errorf("user %q should be valid: %v", user, err)
+		}
+	}
+}
+
+func TestValidateDesktopInvalidUser(t *testing.T) {
+	tests := []struct {
+		user string
+		desc string
+	}{
+		{"root", "root is reserved"},
+		{"Root", "uppercase not allowed"},
+		{"my user", "spaces not allowed"},
+		{strings.Repeat("a", 33), "exceeds 32 chars"},
+	}
+	for _, tt := range tests {
+		cfg := &DesktopConfig{
+			Name: "test",
+			Base: BaseSpec{OS: "ubuntu", Desktop: "xfce"},
+			User: tt.user,
+		}
+		if err := ValidateDesktop(cfg); err == nil {
+			t.Errorf("user %q (%s) should be invalid", tt.user, tt.desc)
+		}
+	}
+}
+
+func TestValidateDesktopCustomHome(t *testing.T) {
+	// Valid absolute paths
+	for _, home := range []string{"/home/carlos", "/workspace", "/"} {
+		cfg := &DesktopConfig{
+			Name: "test",
+			Base: BaseSpec{OS: "ubuntu", Desktop: "xfce"},
+			Home: home,
+		}
+		if err := ValidateDesktop(cfg); err != nil {
+			t.Errorf("home %q should be valid: %v", home, err)
+		}
+	}
+	// Invalid: relative path
+	cfg := &DesktopConfig{
+		Name: "test",
+		Base: BaseSpec{OS: "ubuntu", Desktop: "xfce"},
+		Home: "home/carlos",
+	}
+	if err := ValidateDesktop(cfg); err == nil {
+		t.Error("relative home path should be invalid")
+	}
+}
+
+// --- EffectiveUser / EffectiveHome ---
+
+func TestEffectiveUserHome(t *testing.T) {
+	tests := []struct {
+		user     string
+		home     string
+		wantUser string
+		wantHome string
+	}{
+		{"", "", "desktopus", "/home/desktopus"},
+		{"abc", "", "abc", "/config"},
+		{"carlos", "", "carlos", "/home/carlos"},
+		{"carlos", "/workspace", "carlos", "/workspace"},
+	}
+	for _, tt := range tests {
+		cfg := &DesktopConfig{User: tt.user, Home: tt.home}
+		if got := cfg.EffectiveUser(); got != tt.wantUser {
+			t.Errorf("user=%q home=%q: EffectiveUser()=%q, want %q", tt.user, tt.home, got, tt.wantUser)
+		}
+		if got := cfg.EffectiveHome(); got != tt.wantHome {
+			t.Errorf("user=%q home=%q: EffectiveHome()=%q, want %q", tt.user, tt.home, got, tt.wantHome)
+		}
 	}
 }
 

--- a/internal/config/desktop.go
+++ b/internal/config/desktop.go
@@ -6,12 +6,39 @@ import "fmt"
 type DesktopConfig struct {
 	Name        string            `yaml:"name"`
 	Description string            `yaml:"description,omitempty"`
+	User        string            `yaml:"user,omitempty"`
+	Home        string            `yaml:"home,omitempty"`
 	Base        BaseSpec          `yaml:"base"`
 	Modules     []ModuleRef       `yaml:"modules,omitempty"`
 	Env         map[string]EnvVar `yaml:"env,omitempty"`
 	PostRun     []PostRunScript   `yaml:"postrun,omitempty"`
 	Files       []FileSpec        `yaml:"files,omitempty"`
 	Runtime     RuntimeSpec       `yaml:"runtime,omitempty"`
+}
+
+// EffectiveUser returns the resolved Linux username for this desktop.
+// If user is "abc", returns "abc" (the built-in linuxserver/webtop user).
+// If user is unset, defaults to "desktopus".
+// Otherwise returns the configured user.
+func (d *DesktopConfig) EffectiveUser() string {
+	if d.User == "" {
+		return "desktopus"
+	}
+	return d.User
+}
+
+// EffectiveHome returns the resolved home directory for this desktop.
+// If user is "abc", returns "/config" (the built-in linuxserver/webtop home).
+// If home is explicitly set, returns that value.
+// Otherwise returns "/home/<effective-user>".
+func (d *DesktopConfig) EffectiveHome() string {
+	if d.User == "abc" {
+		return "/config"
+	}
+	if d.Home != "" {
+		return d.Home
+	}
+	return "/home/" + d.EffectiveUser()
 }
 
 // BaseSpec defines the OS and desktop environment
@@ -75,7 +102,7 @@ type EnvVar struct {
 // PostRunScript defines a script that runs at container startup via s6
 type PostRunScript struct {
 	Name   string `yaml:"name"`
-	RunAs  string `yaml:"runas,omitempty"` // "root" or "abc" (default: "abc")
+	RunAs  string `yaml:"runas,omitempty"` // "root" or the configured user (default: configured user)
 	Script string `yaml:"script"`
 }
 

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -8,6 +8,7 @@ import (
 )
 
 var validName = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$`)
+var validLinuxUsername = regexp.MustCompile(`^[a-z_][a-z0-9_-]*$`)
 
 // compatMatrix maps each supported OS to its available desktop environments.
 // This reflects the actual linuxserver/webtop image tags.
@@ -54,6 +55,20 @@ func ValidateDesktop(cfg *DesktopConfig) error {
 		errs = append(errs, fmt.Sprintf("name %q must be DNS-safe: lowercase alphanumeric and hyphens", cfg.Name))
 	}
 
+	if cfg.User != "" {
+		if cfg.User == "root" {
+			errs = append(errs, "user must not be 'root'")
+		} else if !validLinuxUsername.MatchString(cfg.User) {
+			errs = append(errs, fmt.Sprintf("user %q is not a valid Linux username (must match [a-z_][a-z0-9_-]*)", cfg.User))
+		} else if len(cfg.User) > 32 {
+			errs = append(errs, fmt.Sprintf("user %q exceeds maximum length of 32 characters", cfg.User))
+		}
+	}
+
+	if cfg.Home != "" && !strings.HasPrefix(cfg.Home, "/") {
+		errs = append(errs, fmt.Sprintf("home %q must be an absolute path", cfg.Home))
+	}
+
 	desktops := compatMatrix[cfg.Base.OS]
 
 	if cfg.Base.OS == "" {
@@ -81,8 +96,8 @@ func ValidateDesktop(cfg *DesktopConfig) error {
 		if pr.Script == "" {
 			errs = append(errs, fmt.Sprintf("postrun[%d]: script is required", i))
 		}
-		if pr.RunAs != "" && pr.RunAs != "root" && pr.RunAs != "abc" {
-			errs = append(errs, fmt.Sprintf("postrun[%d]: runas must be 'root' or 'abc'", i))
+		if pr.RunAs != "" && pr.RunAs != "root" && pr.RunAs != cfg.EffectiveUser() {
+			errs = append(errs, fmt.Sprintf("postrun[%d]: runas must be 'root' or '%s'", i, cfg.EffectiveUser()))
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Add optional `user` and `home` top-level fields to `desktopus.yaml`
- Default (no `user` set): creates a `desktopus` user at `/home/desktopus` via `RUN useradd`
- `user: abc`: uses the built-in linuxserver/webtop user with home `/config` — no `useradd` emitted
- Custom user (e.g. `user: carlos`): emits `RUN useradd` with the resolved home directory
- `desktopus_user` / `desktopus_home` Ansible vars, post-run script `runas` defaults, and `chown` in the runtime file provisioner all resolve dynamically to the effective user