### PR TITLE
feat: split desktopus.yaml into image + runtime configs

### DIFF
--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -151,7 +151,7 @@ func TestGenerateDockerfile(t *testing.T) {
 		t.Fatalf("parse template: %v", err)
 	}
 
-	cfg := &config.DesktopConfig{
+	cfg := &config.ImageConfig{
 		Name:        "test-desktop",
 		Description: "A test desktop",
 		Base:        config.BaseSpec{OS: "ubuntu", Desktop: "xfce"},
@@ -203,7 +203,7 @@ func TestGenerateDockerfileFedora(t *testing.T) {
 		t.Fatalf("parse template: %v", err)
 	}
 
-	cfg := &config.DesktopConfig{
+	cfg := &config.ImageConfig{
 		Name: "fedora-desktop",
 		Base: config.BaseSpec{OS: "fedora", Desktop: "xfce"},
 	}
@@ -239,7 +239,7 @@ func TestGenerateDockerfileArch(t *testing.T) {
 		t.Fatalf("parse template: %v", err)
 	}
 
-	cfg := &config.DesktopConfig{
+	cfg := &config.ImageConfig{
 		Name: "arch-desktop",
 		Base: config.BaseSpec{OS: "arch", Desktop: "i3"},
 	}
@@ -272,7 +272,7 @@ func TestGenerateDockerfileAlpine(t *testing.T) {
 		t.Fatalf("parse template: %v", err)
 	}
 
-	cfg := &config.DesktopConfig{
+	cfg := &config.ImageConfig{
 		Name: "alpine-desktop",
 		Base: config.BaseSpec{OS: "alpine", Desktop: "xfce"},
 	}
@@ -305,7 +305,7 @@ func TestGenerateDockerfileEL(t *testing.T) {
 		t.Fatalf("parse template: %v", err)
 	}
 
-	cfg := &config.DesktopConfig{
+	cfg := &config.ImageConfig{
 		Name: "el-desktop",
 		Base: config.BaseSpec{OS: "el", Desktop: "xfce"},
 	}
@@ -335,7 +335,7 @@ func TestGenerateDockerfileWithPostRun(t *testing.T) {
 		t.Fatalf("parse template: %v", err)
 	}
 
-	cfg := &config.DesktopConfig{
+	cfg := &config.ImageConfig{
 		Name: "test",
 		Base: config.BaseSpec{OS: "ubuntu", Desktop: "xfce"},
 		PostRun: []config.PostRunScript{
@@ -360,7 +360,7 @@ func TestGenerateDockerfileWithVerbosity(t *testing.T) {
 		t.Fatalf("parse template: %v", err)
 	}
 
-	cfg := &config.DesktopConfig{
+	cfg := &config.ImageConfig{
 		Name: "test",
 		Base: config.BaseSpec{OS: "ubuntu", Desktop: "xfce"},
 	}
@@ -382,7 +382,7 @@ func TestGenerateDockerfileDeduplicatesPackages(t *testing.T) {
 		t.Fatalf("parse template: %v", err)
 	}
 
-	cfg := &config.DesktopConfig{
+	cfg := &config.ImageConfig{
 		Name: "test",
 		Base: config.BaseSpec{OS: "ubuntu", Desktop: "xfce"},
 	}
@@ -541,7 +541,7 @@ func TestGeneratePlaybookOSFallback(t *testing.T) {
 
 func TestAddPostRunScripts(t *testing.T) {
 	bctx := NewBuildContext()
-	cfg := &config.DesktopConfig{
+	cfg := &config.ImageConfig{
 		PostRun: []config.PostRunScript{
 			{Name: "setup-git", RunAs: "abc", Script: "git config --global user.name test"},
 			{Name: "root-setup", RunAs: "root", Script: "apt-get update"},
@@ -598,7 +598,7 @@ func TestAddPostRunScripts(t *testing.T) {
 
 func TestAddPostRunScriptsDefaultRunAs(t *testing.T) {
 	bctx := NewBuildContext()
-	cfg := &config.DesktopConfig{
+	cfg := &config.ImageConfig{
 		PostRun: []config.PostRunScript{
 			{Name: "test", Script: "echo hi"}, // no RunAs specified
 		},
@@ -633,7 +633,7 @@ func TestAddPostRunScriptsDefaultRunAs(t *testing.T) {
 
 func TestAddRuntimeFiles(t *testing.T) {
 	bctx := NewBuildContext()
-	cfg := &config.DesktopConfig{
+	cfg := &config.ImageConfig{
 		Files: []config.FileSpec{
 			{Path: "/config/.bashrc", Content: "export PS1='\\u@\\h'", Mode: "0644"},
 			{Path: "/config/.vimrc", Content: "set number"},
@@ -686,7 +686,7 @@ func TestAddRuntimeFiles(t *testing.T) {
 
 func TestAddRuntimeFilesEmpty(t *testing.T) {
 	bctx := NewBuildContext()
-	cfg := &config.DesktopConfig{} // no files
+	cfg := &config.ImageConfig{} // no files
 
 	if err := addRuntimeFiles(bctx, cfg); err != nil {
 		t.Fatalf("addRuntimeFiles: %v", err)
@@ -843,7 +843,7 @@ func TestGenerateDockerfileDefaultUser(t *testing.T) {
 		t.Fatalf("parse template: %v", err)
 	}
 
-	cfg := &config.DesktopConfig{
+	cfg := &config.ImageConfig{
 		Name: "test",
 		Base: config.BaseSpec{OS: "ubuntu", Desktop: "xfce"},
 		// User omitted → creates "desktopus" with home "/home/desktopus"
@@ -876,7 +876,7 @@ func TestGenerateDockerfileAbcUser(t *testing.T) {
 		t.Fatalf("parse template: %v", err)
 	}
 
-	cfg := &config.DesktopConfig{
+	cfg := &config.ImageConfig{
 		Name: "test",
 		Base: config.BaseSpec{OS: "ubuntu", Desktop: "xfce"},
 		User: "abc",
@@ -909,7 +909,7 @@ func TestGenerateDockerfileCustomUser(t *testing.T) {
 		t.Fatalf("parse template: %v", err)
 	}
 
-	cfg := &config.DesktopConfig{
+	cfg := &config.ImageConfig{
 		Name: "test",
 		Base: config.BaseSpec{OS: "ubuntu", Desktop: "xfce"},
 		User: "carlos",
@@ -978,7 +978,7 @@ func TestGeneratePlaybookCustomUser(t *testing.T) {
 
 func TestAddPostRunScriptsDefaultUser(t *testing.T) {
 	bctx := NewBuildContext()
-	cfg := &config.DesktopConfig{
+	cfg := &config.ImageConfig{
 		// User omitted → effective user is "desktopus"
 		PostRun: []config.PostRunScript{
 			{Name: "test", Script: "echo hi"},
@@ -1010,7 +1010,7 @@ func TestAddPostRunScriptsDefaultUser(t *testing.T) {
 
 func TestAddRuntimeFilesDefaultUser(t *testing.T) {
 	bctx := NewBuildContext()
-	cfg := &config.DesktopConfig{
+	cfg := &config.ImageConfig{
 		// User omitted → effective user is "desktopus"
 		Files: []config.FileSpec{
 			{Path: "/home/desktopus/.bashrc", Content: "# bashrc"},

--- a/internal/build/dockerfile.go
+++ b/internal/build/dockerfile.go
@@ -25,7 +25,7 @@ type dockerfileData struct {
 }
 
 // generateDockerfile renders the Dockerfile from the template and config
-func generateDockerfile(tmpl *template.Template, cfg *config.DesktopConfig, modules []*module.Module, ansibleVerbosity int) ([]byte, error) {
+func generateDockerfile(tmpl *template.Template, cfg *config.ImageConfig, modules []*module.Module, ansibleVerbosity int) ([]byte, error) {
 	// Collect all system packages from modules
 	pkgSet := make(map[string]bool)
 	for _, mod := range modules {

--- a/internal/build/pipeline.go
+++ b/internal/build/pipeline.go
@@ -43,7 +43,7 @@ func NewPipeline(docker *client.Client, registry *module.Registry) *Pipeline {
 }
 
 // Build builds a Docker image from a desktop config
-func (p *Pipeline) Build(ctx context.Context, cfg *config.DesktopConfig, configDir string, opts Options, output io.Writer) error {
+func (p *Pipeline) Build(ctx context.Context, cfg *config.ImageConfig, configDir string, opts Options, output io.Writer) error {
 	// 1. Resolve all modules
 	modules, varsOverrides, err := p.resolveModules(cfg, configDir)
 	if err != nil {
@@ -133,7 +133,7 @@ func (p *Pipeline) Build(ctx context.Context, cfg *config.DesktopConfig, configD
 	return streamBuildOutput(resp.Body, output)
 }
 
-func (p *Pipeline) resolveModules(cfg *config.DesktopConfig, configDir string) ([]*module.Module, []map[string]interface{}, error) {
+func (p *Pipeline) resolveModules(cfg *config.ImageConfig, configDir string) ([]*module.Module, []map[string]interface{}, error) {
 	modules := make([]*module.Module, 0, len(cfg.Modules))
 	varsOverrides := make([]map[string]interface{}, 0, len(cfg.Modules))
 
@@ -197,7 +197,7 @@ func (p *Pipeline) addModuleFiles(bctx *BuildContext, modules []*module.Module) 
 	return nil
 }
 
-func addPostRunScripts(bctx *BuildContext, cfg *config.DesktopConfig) error {
+func addPostRunScripts(bctx *BuildContext, cfg *config.ImageConfig) error {
 	for i, pr := range cfg.PostRun {
 		runas := pr.RunAs
 		if runas == "" {
@@ -219,7 +219,7 @@ func addPostRunScripts(bctx *BuildContext, cfg *config.DesktopConfig) error {
 	return nil
 }
 
-func addRuntimeFiles(bctx *BuildContext, cfg *config.DesktopConfig) error {
+func addRuntimeFiles(bctx *BuildContext, cfg *config.ImageConfig) error {
 	if len(cfg.Files) == 0 {
 		return nil
 	}

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -32,12 +32,12 @@ var buildCmd = &cobra.Command{
 		}
 
 		// Find and load config
-		configPath, err := config.FindDesktopConfig(path)
+		configPath, err := config.FindImageConfig(path)
 		if err != nil {
 			return err
 		}
 
-		cfg, err := config.LoadDesktop(configPath)
+		cfg, err := config.LoadImage(configPath)
 		if err != nil {
 			return err
 		}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -30,26 +30,31 @@ var initCmd = &cobra.Command{
 			dir = "."
 		}
 
-		outputPath := filepath.Join(dir, "desktopus.yaml")
-		if _, err := os.Stat(outputPath); err == nil {
+		imagePath := filepath.Join(dir, "desktopus.yaml")
+		if _, err := os.Stat(imagePath); err == nil {
 			return fmt.Errorf("desktopus.yaml already exists in %s", dir)
 		}
-
-		content := generateInitYAML(name, initOS, initDesktop)
 
 		if err := os.MkdirAll(dir, 0755); err != nil {
 			return fmt.Errorf("creating directory: %w", err)
 		}
 
-		if err := os.WriteFile(outputPath, []byte(content), 0644); err != nil {
+		if err := os.WriteFile(imagePath, []byte(generateImageYAML(name, initOS, initDesktop)), 0644); err != nil {
 			return fmt.Errorf("writing desktopus.yaml: %w", err)
 		}
 
-		fmt.Printf("Created %s\n", outputPath)
+		runtimePath := filepath.Join(dir, "desktopus.runtime.yaml")
+		if err := os.WriteFile(runtimePath, []byte(generateRuntimeYAML()), 0644); err != nil {
+			return fmt.Errorf("writing desktopus.runtime.yaml: %w", err)
+		}
+
+		fmt.Printf("Created %s\n", imagePath)
+		fmt.Printf("Created %s\n", runtimePath)
 		fmt.Printf("\nNext steps:\n")
 		fmt.Printf("  1. Edit desktopus.yaml to customize your desktop\n")
-		fmt.Printf("  2. Run: desktopus build .\n")
-		fmt.Printf("  3. Run: desktopus run %s\n", name)
+		fmt.Printf("  2. Edit desktopus.runtime.yaml for machine-local settings (ports, volumes, GPU)\n")
+		fmt.Printf("  3. Run: desktopus build .\n")
+		fmt.Printf("  4. Run: desktopus run %s\n", name)
 		return nil
 	},
 }
@@ -60,7 +65,7 @@ func init() {
 	initCmd.Flags().StringVar(&initDir, "dir", "", "output directory (default: current)")
 }
 
-func generateInitYAML(name, osName, desktop string) string {
+func generateImageYAML(name, osName, desktop string) string {
 	return fmt.Sprintf(`name: %s
 description: "My desktop environment"
 
@@ -81,18 +86,20 @@ modules:
 #     runas: abc
 #     script: |
 #       echo "Hello from post-run script"
-
-runtime:
-  shm_size: 2g
-  ports:
-    - "3000:3000"
-    - "3001:3001"
-    - "8082:8082"
-  # volumes:
-  #   - ~/projects:/config/projects
-  env:
-    PUID: "1000"
-    PGID: "1000"
-    TZ: UTC
 `, name, osName, desktop)
+}
+
+func generateRuntimeYAML() string {
+	return `shm_size: 2g
+ports:
+  - "3000:3000"
+  - "3001:3001"
+  - "8082:8082"
+# volumes:
+#   - ~/projects:/config/projects
+env:
+  PUID: "1000"
+  PGID: "1000"
+  TZ: UTC
+`
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -35,18 +35,24 @@ var runCmd = &cobra.Command{
 			file = "."
 		}
 
-		configPath, err := config.FindDesktopConfig(file)
+		configPath, err := config.FindImageConfig(file)
 		if err != nil {
 			return err
 		}
 
-		cfg, err := config.LoadDesktop(configPath)
+		img, err := config.LoadImage(configPath)
+		if err != nil {
+			return err
+		}
+
+		runtimePath := config.FindRuntimeConfig(configPath)
+		rt, err := config.LoadRuntime(runtimePath)
 		if err != nil {
 			return err
 		}
 
 		// Validate required env vars
-		if err := validateRequiredEnv(cfg, runEnvs); err != nil {
+		if err := validateRequiredEnv(img, rt, runEnvs); err != nil {
 			return err
 		}
 
@@ -78,18 +84,18 @@ var runCmd = &cobra.Command{
 			Remove:  runRemove,
 		}
 
-		// Build the runtime config from the desktop config
-		runCfg := toDesktopRunConfig(cfg)
+		// Build the runtime config from the image and runtime configs
+		runCfg := toDesktopRunConfig(img, rt)
 
 		containerID, err := mgr.Run(context.Background(), runCfg, opts, os.Stdout)
 		if err != nil {
 			return fmt.Errorf("failed to run desktop: %w", err)
 		}
 
-		fmt.Printf("Desktop %q running (container: %s)\n", cfg.Name, containerID[:12])
+		fmt.Printf("Desktop %q running (container: %s)\n", img.Name, containerID[:12])
 
 		// Find the web port
-		webPort := findWebPort(cfg)
+		webPort := findWebPort(rt)
 		if webPort != "" {
 			fmt.Printf("  Web: http://localhost:%s\n", webPort)
 		}
@@ -109,18 +115,18 @@ func init() {
 	runCmd.Flags().BoolVar(&runRemove, "rm", false, "remove container when stopped")
 }
 
-func validateRequiredEnv(cfg *config.DesktopConfig, cliEnvs []string) error {
+func validateRequiredEnv(img *config.ImageConfig, rt *config.RuntimeConfig, cliEnvs []string) error {
 	provided := make(map[string]bool)
 
 	// From defaults
-	for name, spec := range cfg.Env {
+	for name, spec := range img.Env {
 		if spec.Default != "" {
 			provided[name] = true
 		}
 	}
 
-	// From runtime.env
-	for k := range cfg.Runtime.Env {
+	// From runtime env
+	for k := range rt.Env {
 		provided[k] = true
 	}
 
@@ -133,7 +139,7 @@ func validateRequiredEnv(cfg *config.DesktopConfig, cliEnvs []string) error {
 	}
 
 	var missing []string
-	for name, spec := range cfg.Env {
+	for name, spec := range img.Env {
 		if spec.Required && !provided[name] {
 			missing = append(missing, name)
 		}
@@ -145,8 +151,8 @@ func validateRequiredEnv(cfg *config.DesktopConfig, cliEnvs []string) error {
 	return nil
 }
 
-func findWebPort(cfg *config.DesktopConfig) string {
-	for _, p := range cfg.Runtime.Ports {
+func findWebPort(rt *config.RuntimeConfig) string {
+	for _, p := range rt.Ports {
 		parts := strings.SplitN(p, ":", 2)
 		if len(parts) == 2 && parts[1] == "3000" {
 			return parts[0]
@@ -155,30 +161,30 @@ func findWebPort(cfg *config.DesktopConfig) string {
 	return ""
 }
 
-// toDesktopRunConfig converts a DesktopConfig into a runtime DesktopRunConfig
-func toDesktopRunConfig(cfg *config.DesktopConfig) *runtime.DesktopRunConfig {
+// toDesktopRunConfig converts ImageConfig + RuntimeConfig into a runtime DesktopRunConfig
+func toDesktopRunConfig(img *config.ImageConfig, rt *config.RuntimeConfig) *runtime.DesktopRunConfig {
 	env := make(map[string]string)
-	for name, spec := range cfg.Env {
+	for name, spec := range img.Env {
 		if spec.Default != "" {
 			env[name] = spec.Default
 		}
 	}
-	for k, v := range cfg.Runtime.Env {
+	for k, v := range rt.Env {
 		env[k] = v
 	}
 
 	return &runtime.DesktopRunConfig{
-		Name:     cfg.Name,
-		ImageTag: cfg.ImageTag(),
-		Hostname: cfg.Runtime.Hostname,
-		ShmSize:  cfg.Runtime.ShmSize,
-		Ports:    cfg.Runtime.Ports,
-		Volumes:  cfg.Runtime.Volumes,
-		GPU:      cfg.Runtime.GPU,
-		Memory:   cfg.Runtime.Memory,
-		CPUs:     cfg.Runtime.CPUs,
-		Restart:  cfg.Runtime.Restart,
-		Network:  cfg.Runtime.Network,
+		Name:     img.Name,
+		ImageTag: img.ImageTag(),
+		Hostname: rt.Hostname,
+		ShmSize:  rt.ShmSize,
+		Ports:    rt.Ports,
+		Volumes:  rt.Volumes,
+		GPU:      rt.GPU,
+		Memory:   rt.Memory,
+		CPUs:     rt.CPUs,
+		Restart:  rt.Restart,
+		Network:  rt.Network,
 		Env:      env,
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -43,10 +43,10 @@ func TestImageRefCustomTag(t *testing.T) {
 	}
 }
 
-// --- DesktopConfig.ImageTag ---
+// --- ImageConfig.ImageTag ---
 
 func TestImageTag(t *testing.T) {
-	cfg := DesktopConfig{Name: "my-desktop"}
+	cfg := ImageConfig{Name: "my-desktop"}
 	want := "desktopus/my-desktop:latest"
 	if got := cfg.ImageTag(); got != want {
 		t.Errorf("ImageTag() = %q, want %q", got, want)
@@ -133,33 +133,33 @@ modules:
 	}
 }
 
-// --- ValidateDesktop ---
+// --- ValidateImage ---
 
-func TestValidateDesktopValid(t *testing.T) {
-	cfg := &DesktopConfig{
+func TestValidateImageValid(t *testing.T) {
+	cfg := &ImageConfig{
 		Name: "my-desktop",
 		Base: BaseSpec{OS: "ubuntu", Desktop: "xfce"},
 	}
-	if err := ValidateDesktop(cfg); err != nil {
+	if err := ValidateImage(cfg); err != nil {
 		t.Errorf("expected valid config, got: %v", err)
 	}
 }
 
-func TestValidateDesktopSingleCharName(t *testing.T) {
-	cfg := &DesktopConfig{
+func TestValidateImageSingleCharName(t *testing.T) {
+	cfg := &ImageConfig{
 		Name: "x",
 		Base: BaseSpec{OS: "ubuntu", Desktop: "xfce"},
 	}
-	if err := ValidateDesktop(cfg); err != nil {
+	if err := ValidateImage(cfg); err != nil {
 		t.Errorf("single-char name should be valid: %v", err)
 	}
 }
 
-func TestValidateDesktopMissingName(t *testing.T) {
-	cfg := &DesktopConfig{
+func TestValidateImageMissingName(t *testing.T) {
+	cfg := &ImageConfig{
 		Base: BaseSpec{OS: "ubuntu", Desktop: "xfce"},
 	}
-	err := ValidateDesktop(cfg)
+	err := ValidateImage(cfg)
 	if err == nil {
 		t.Error("expected error for missing name")
 	}
@@ -168,7 +168,7 @@ func TestValidateDesktopMissingName(t *testing.T) {
 	}
 }
 
-func TestValidateDesktopInvalidName(t *testing.T) {
+func TestValidateImageInvalidName(t *testing.T) {
 	tests := []string{
 		"My-Desktop",  // uppercase
 		"-bad",        // starts with hyphen
@@ -177,22 +177,22 @@ func TestValidateDesktopInvalidName(t *testing.T) {
 		"under_score", // underscore
 	}
 	for _, name := range tests {
-		cfg := &DesktopConfig{
+		cfg := &ImageConfig{
 			Name: name,
 			Base: BaseSpec{OS: "ubuntu", Desktop: "xfce"},
 		}
-		if err := ValidateDesktop(cfg); err == nil {
+		if err := ValidateImage(cfg); err == nil {
 			t.Errorf("expected error for name %q", name)
 		}
 	}
 }
 
-func TestValidateDesktopInvalidOS(t *testing.T) {
-	cfg := &DesktopConfig{
+func TestValidateImageInvalidOS(t *testing.T) {
+	cfg := &ImageConfig{
 		Name: "test",
 		Base: BaseSpec{OS: "windows", Desktop: "xfce"},
 	}
-	err := ValidateDesktop(cfg)
+	err := ValidateImage(cfg)
 	if err == nil {
 		t.Error("expected error for invalid OS")
 	}
@@ -201,47 +201,47 @@ func TestValidateDesktopInvalidOS(t *testing.T) {
 	}
 }
 
-func TestValidateDesktopInvalidDesktopEnv(t *testing.T) {
-	cfg := &DesktopConfig{
+func TestValidateImageInvalidDesktopEnv(t *testing.T) {
+	cfg := &ImageConfig{
 		Name: "test",
 		Base: BaseSpec{OS: "ubuntu", Desktop: "gnome"},
 	}
-	err := ValidateDesktop(cfg)
+	err := ValidateImage(cfg)
 	if err == nil {
 		t.Error("expected error for invalid desktop")
 	}
 }
 
-func TestValidateDesktopAllValidOS(t *testing.T) {
+func TestValidateImageAllValidOS(t *testing.T) {
 	for _, os := range []string{"ubuntu", "debian", "fedora", "arch", "alpine", "el"} {
-		cfg := &DesktopConfig{
+		cfg := &ImageConfig{
 			Name: "test",
 			Base: BaseSpec{OS: os, Desktop: "xfce"},
 		}
-		if err := ValidateDesktop(cfg); err != nil {
+		if err := ValidateImage(cfg); err != nil {
 			t.Errorf("OS %q should be valid: %v", os, err)
 		}
 	}
 }
 
-func TestValidateDesktopAllValidDesktops(t *testing.T) {
+func TestValidateImageAllValidDesktops(t *testing.T) {
 	for _, de := range []string{"xfce", "kde", "i3", "mate"} {
-		cfg := &DesktopConfig{
+		cfg := &ImageConfig{
 			Name: "test",
 			Base: BaseSpec{OS: "ubuntu", Desktop: de},
 		}
-		if err := ValidateDesktop(cfg); err != nil {
+		if err := ValidateImage(cfg); err != nil {
 			t.Errorf("desktop %q should be valid: %v", de, err)
 		}
 	}
 }
 
-func TestValidateDesktopIncompatibleCombo(t *testing.T) {
-	cfg := &DesktopConfig{
+func TestValidateImageIncompatibleCombo(t *testing.T) {
+	cfg := &ImageConfig{
 		Name: "test",
 		Base: BaseSpec{OS: "el", Desktop: "kde"},
 	}
-	err := ValidateDesktop(cfg)
+	err := ValidateImage(cfg)
 	if err == nil {
 		t.Error("expected error for el + kde (incompatible)")
 	}
@@ -250,39 +250,39 @@ func TestValidateDesktopIncompatibleCombo(t *testing.T) {
 	}
 }
 
-func TestValidateDesktopELValidCombos(t *testing.T) {
+func TestValidateImageELValidCombos(t *testing.T) {
 	for _, de := range []string{"i3", "mate", "xfce"} {
-		cfg := &DesktopConfig{
+		cfg := &ImageConfig{
 			Name: "test",
 			Base: BaseSpec{OS: "el", Desktop: de},
 		}
-		if err := ValidateDesktop(cfg); err != nil {
+		if err := ValidateImage(cfg); err != nil {
 			t.Errorf("el + %q should be valid: %v", de, err)
 		}
 	}
 }
 
-func TestValidateDesktopRemovedDesktops(t *testing.T) {
+func TestValidateImageRemovedDesktops(t *testing.T) {
 	for _, de := range []string{"openbox", "icewm"} {
-		cfg := &DesktopConfig{
+		cfg := &ImageConfig{
 			Name: "test",
 			Base: BaseSpec{OS: "ubuntu", Desktop: de},
 		}
-		if err := ValidateDesktop(cfg); err == nil {
+		if err := ValidateImage(cfg); err == nil {
 			t.Errorf("desktop %q should be rejected", de)
 		}
 	}
 }
 
-func TestValidateDesktopPostRunInvalidRunAs(t *testing.T) {
-	cfg := &DesktopConfig{
+func TestValidateImagePostRunInvalidRunAs(t *testing.T) {
+	cfg := &ImageConfig{
 		Name: "test",
 		Base: BaseSpec{OS: "ubuntu", Desktop: "xfce"},
 		PostRun: []PostRunScript{
 			{Name: "setup", Script: "echo hi", RunAs: "nobody"},
 		},
 	}
-	err := ValidateDesktop(cfg)
+	err := ValidateImage(cfg)
 	if err == nil {
 		t.Error("expected error for invalid runas")
 	}
@@ -291,22 +291,22 @@ func TestValidateDesktopPostRunInvalidRunAs(t *testing.T) {
 	}
 }
 
-func TestValidateDesktopPostRunValidRunAs(t *testing.T) {
+func TestValidateImagePostRunValidRunAs(t *testing.T) {
 	// Default user is "desktopus" when no user is set
 	for _, runas := range []string{"", "root", "desktopus"} {
-		cfg := &DesktopConfig{
+		cfg := &ImageConfig{
 			Name: "test",
 			Base: BaseSpec{OS: "ubuntu", Desktop: "xfce"},
 			PostRun: []PostRunScript{
 				{Name: "setup", Script: "echo hi", RunAs: runas},
 			},
 		}
-		if err := ValidateDesktop(cfg); err != nil {
+		if err := ValidateImage(cfg); err != nil {
 			t.Errorf("runas %q should be valid: %v", runas, err)
 		}
 	}
 	// Custom user: runas must match the configured user
-	cfg := &DesktopConfig{
+	cfg := &ImageConfig{
 		Name: "test",
 		Base: BaseSpec{OS: "ubuntu", Desktop: "xfce"},
 		User: "carlos",
@@ -314,14 +314,14 @@ func TestValidateDesktopPostRunValidRunAs(t *testing.T) {
 			{Name: "setup", Script: "echo hi", RunAs: "carlos"},
 		},
 	}
-	if err := ValidateDesktop(cfg); err != nil {
+	if err := ValidateImage(cfg); err != nil {
 		t.Errorf("runas 'carlos' should be valid for user 'carlos': %v", err)
 	}
 }
 
-func TestValidateDesktopMultipleErrors(t *testing.T) {
-	cfg := &DesktopConfig{} // missing everything
-	err := ValidateDesktop(cfg)
+func TestValidateImageMultipleErrors(t *testing.T) {
+	cfg := &ImageConfig{} // missing everything
+	err := ValidateImage(cfg)
 	if err == nil {
 		t.Fatal("expected errors")
 	}
@@ -331,40 +331,40 @@ func TestValidateDesktopMultipleErrors(t *testing.T) {
 	}
 }
 
-func TestValidateDesktopModuleMissingName(t *testing.T) {
-	cfg := &DesktopConfig{
+func TestValidateImageModuleMissingName(t *testing.T) {
+	cfg := &ImageConfig{
 		Name:    "test",
 		Base:    BaseSpec{OS: "ubuntu", Desktop: "xfce"},
 		Modules: []ModuleRef{{Name: ""}},
 	}
-	err := ValidateDesktop(cfg)
+	err := ValidateImage(cfg)
 	if err == nil {
 		t.Error("expected error for module without name")
 	}
 }
 
-func TestValidateDesktopFilesMissingPath(t *testing.T) {
-	cfg := &DesktopConfig{
+func TestValidateImageFilesMissingPath(t *testing.T) {
+	cfg := &ImageConfig{
 		Name: "test",
 		Base: BaseSpec{OS: "ubuntu", Desktop: "xfce"},
 		Files: []FileSpec{{Content: "hello"}},
 	}
-	err := ValidateDesktop(cfg)
+	err := ValidateImage(cfg)
 	if err == nil {
 		t.Error("expected error for file without path")
 	}
 }
 
-// --- FindDesktopConfig ---
+// --- FindImageConfig ---
 
-func TestFindDesktopConfigFromDir(t *testing.T) {
+func TestFindImageConfigFromDir(t *testing.T) {
 	dir := t.TempDir()
 	configFile := filepath.Join(dir, "desktopus.yaml")
 	if err := os.WriteFile(configFile, []byte("name: test"), 0644); err != nil {
 		t.Fatal(err)
 	}
 
-	got, err := FindDesktopConfig(dir)
+	got, err := FindImageConfig(dir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -373,14 +373,14 @@ func TestFindDesktopConfigFromDir(t *testing.T) {
 	}
 }
 
-func TestFindDesktopConfigFromFile(t *testing.T) {
+func TestFindImageConfigFromFile(t *testing.T) {
 	dir := t.TempDir()
 	configFile := filepath.Join(dir, "custom.yaml")
 	if err := os.WriteFile(configFile, []byte("name: test"), 0644); err != nil {
 		t.Fatal(err)
 	}
 
-	got, err := FindDesktopConfig(configFile)
+	got, err := FindImageConfig(configFile)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -389,25 +389,25 @@ func TestFindDesktopConfigFromFile(t *testing.T) {
 	}
 }
 
-func TestFindDesktopConfigMissing(t *testing.T) {
+func TestFindImageConfigMissing(t *testing.T) {
 	dir := t.TempDir()
 
-	_, err := FindDesktopConfig(dir)
+	_, err := FindImageConfig(dir)
 	if err == nil {
 		t.Error("expected error when no desktopus.yaml in directory")
 	}
 }
 
-func TestFindDesktopConfigBadPath(t *testing.T) {
-	_, err := FindDesktopConfig("/nonexistent/path")
+func TestFindImageConfigBadPath(t *testing.T) {
+	_, err := FindImageConfig("/nonexistent/path")
 	if err == nil {
 		t.Error("expected error for nonexistent path")
 	}
 }
 
-// --- LoadDesktop ---
+// --- LoadImage ---
 
-func TestLoadDesktop(t *testing.T) {
+func TestLoadImage(t *testing.T) {
 	dir := t.TempDir()
 	configFile := filepath.Join(dir, "desktopus.yaml")
 
@@ -421,18 +421,12 @@ modules:
   - name: vscode
     vars:
       theme: dark
-runtime:
-  shm_size: 2g
-  ports:
-    - "3000:3000"
-  env:
-    TZ: UTC
 `
 	if err := os.WriteFile(configFile, []byte(yaml), 0644); err != nil {
 		t.Fatal(err)
 	}
 
-	cfg, err := LoadDesktop(configFile)
+	cfg, err := LoadImage(configFile)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -446,28 +440,22 @@ runtime:
 	if len(cfg.Modules) != 2 {
 		t.Errorf("expected 2 modules, got %d", len(cfg.Modules))
 	}
-	if cfg.Runtime.ShmSize != "2g" {
-		t.Errorf("expected shm_size 2g, got %q", cfg.Runtime.ShmSize)
-	}
-	if cfg.Runtime.Env["TZ"] != "UTC" {
-		t.Errorf("expected TZ=UTC, got %q", cfg.Runtime.Env["TZ"])
-	}
 }
 
-func TestLoadDesktopInvalidYAML(t *testing.T) {
+func TestLoadImageInvalidYAML(t *testing.T) {
 	dir := t.TempDir()
 	configFile := filepath.Join(dir, "desktopus.yaml")
 	if err := os.WriteFile(configFile, []byte("{{invalid"), 0644); err != nil {
 		t.Fatal(err)
 	}
 
-	_, err := LoadDesktop(configFile)
+	_, err := LoadImage(configFile)
 	if err == nil {
 		t.Error("expected error for invalid YAML")
 	}
 }
 
-func TestLoadDesktopValidationFails(t *testing.T) {
+func TestLoadImageValidationFails(t *testing.T) {
 	dir := t.TempDir()
 	configFile := filepath.Join(dir, "desktopus.yaml")
 
@@ -481,9 +469,89 @@ base:
 		t.Fatal(err)
 	}
 
-	_, err := LoadDesktop(configFile)
+	_, err := LoadImage(configFile)
 	if err == nil {
 		t.Error("expected validation error")
+	}
+}
+
+// --- LoadRuntime ---
+
+func TestLoadRuntimeMissingFile(t *testing.T) {
+	cfg, err := LoadRuntime("/nonexistent/desktopus.runtime.yaml")
+	if err != nil {
+		t.Fatalf("expected no error for missing runtime file, got: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil zero-value RuntimeConfig")
+	}
+}
+
+func TestLoadRuntime(t *testing.T) {
+	dir := t.TempDir()
+	runtimeFile := filepath.Join(dir, "desktopus.runtime.yaml")
+
+	content := `
+shm_size: 2g
+ports:
+  - "3000:3000"
+env:
+  TZ: UTC
+`
+	if err := os.WriteFile(runtimeFile, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadRuntime(runtimeFile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.ShmSize != "2g" {
+		t.Errorf("expected shm_size 2g, got %q", cfg.ShmSize)
+	}
+	if cfg.Env["TZ"] != "UTC" {
+		t.Errorf("expected TZ=UTC, got %q", cfg.Env["TZ"])
+	}
+}
+
+func TestLoadRuntimeInvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	runtimeFile := filepath.Join(dir, "desktopus.runtime.yaml")
+	if err := os.WriteFile(runtimeFile, []byte("{{invalid"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadRuntime(runtimeFile)
+	if err == nil {
+		t.Error("expected error for invalid YAML")
+	}
+}
+
+// --- FindRuntimeConfig ---
+
+func TestFindRuntimeConfig(t *testing.T) {
+	got := FindRuntimeConfig("/some/dir/desktopus.yaml")
+	want := "/some/dir/desktopus.runtime.yaml"
+	if got != want {
+		t.Errorf("FindRuntimeConfig() = %q, want %q", got, want)
+	}
+}
+
+// --- ValidateRuntime ---
+
+func TestValidateRuntimeValidRestart(t *testing.T) {
+	for _, r := range []string{"", "no", "always", "unless-stopped", "on-failure"} {
+		cfg := &RuntimeConfig{Restart: r}
+		if err := ValidateRuntime(cfg); err != nil {
+			t.Errorf("restart %q should be valid: %v", r, err)
+		}
+	}
+}
+
+func TestValidateRuntimeInvalidRestart(t *testing.T) {
+	cfg := &RuntimeConfig{Restart: "sometimes"}
+	if err := ValidateRuntime(cfg); err == nil {
+		t.Error("expected error for invalid restart policy")
 	}
 }
 
@@ -541,20 +609,20 @@ server:
 
 // --- Custom user validation ---
 
-func TestValidateDesktopCustomUser(t *testing.T) {
+func TestValidateImageCustomUser(t *testing.T) {
 	for _, user := range []string{"carlos", "my_user", "x"} {
-		cfg := &DesktopConfig{
+		cfg := &ImageConfig{
 			Name: "test",
 			Base: BaseSpec{OS: "ubuntu", Desktop: "xfce"},
 			User: user,
 		}
-		if err := ValidateDesktop(cfg); err != nil {
+		if err := ValidateImage(cfg); err != nil {
 			t.Errorf("user %q should be valid: %v", user, err)
 		}
 	}
 }
 
-func TestValidateDesktopInvalidUser(t *testing.T) {
+func TestValidateImageInvalidUser(t *testing.T) {
 	tests := []struct {
 		user string
 		desc string
@@ -565,36 +633,36 @@ func TestValidateDesktopInvalidUser(t *testing.T) {
 		{strings.Repeat("a", 33), "exceeds 32 chars"},
 	}
 	for _, tt := range tests {
-		cfg := &DesktopConfig{
+		cfg := &ImageConfig{
 			Name: "test",
 			Base: BaseSpec{OS: "ubuntu", Desktop: "xfce"},
 			User: tt.user,
 		}
-		if err := ValidateDesktop(cfg); err == nil {
+		if err := ValidateImage(cfg); err == nil {
 			t.Errorf("user %q (%s) should be invalid", tt.user, tt.desc)
 		}
 	}
 }
 
-func TestValidateDesktopCustomHome(t *testing.T) {
+func TestValidateImageCustomHome(t *testing.T) {
 	// Valid absolute paths
 	for _, home := range []string{"/home/carlos", "/workspace", "/"} {
-		cfg := &DesktopConfig{
+		cfg := &ImageConfig{
 			Name: "test",
 			Base: BaseSpec{OS: "ubuntu", Desktop: "xfce"},
 			Home: home,
 		}
-		if err := ValidateDesktop(cfg); err != nil {
+		if err := ValidateImage(cfg); err != nil {
 			t.Errorf("home %q should be valid: %v", home, err)
 		}
 	}
 	// Invalid: relative path
-	cfg := &DesktopConfig{
+	cfg := &ImageConfig{
 		Name: "test",
 		Base: BaseSpec{OS: "ubuntu", Desktop: "xfce"},
 		Home: "home/carlos",
 	}
-	if err := ValidateDesktop(cfg); err == nil {
+	if err := ValidateImage(cfg); err == nil {
 		t.Error("relative home path should be invalid")
 	}
 }
@@ -614,7 +682,7 @@ func TestEffectiveUserHome(t *testing.T) {
 		{"carlos", "/workspace", "carlos", "/workspace"},
 	}
 	for _, tt := range tests {
-		cfg := &DesktopConfig{User: tt.user, Home: tt.home}
+		cfg := &ImageConfig{User: tt.user, Home: tt.home}
 		if got := cfg.EffectiveUser(); got != tt.wantUser {
 			t.Errorf("user=%q home=%q: EffectiveUser()=%q, want %q", tt.user, tt.home, got, tt.wantUser)
 		}

--- a/internal/config/desktop.go
+++ b/internal/config/desktop.go
@@ -2,8 +2,8 @@ package config
 
 import "fmt"
 
-// DesktopConfig is the top-level structure for desktopus.yaml
-type DesktopConfig struct {
+// ImageConfig is the top-level structure for desktopus.yaml
+type ImageConfig struct {
 	Name        string            `yaml:"name"`
 	Description string            `yaml:"description,omitempty"`
 	User        string            `yaml:"user,omitempty"`
@@ -13,14 +13,13 @@ type DesktopConfig struct {
 	Env         map[string]EnvVar `yaml:"env,omitempty"`
 	PostRun     []PostRunScript   `yaml:"postrun,omitempty"`
 	Files       []FileSpec        `yaml:"files,omitempty"`
-	Runtime     RuntimeSpec       `yaml:"runtime,omitempty"`
 }
 
 // EffectiveUser returns the resolved Linux username for this desktop.
 // If user is "abc", returns "abc" (the built-in linuxserver/webtop user).
 // If user is unset, defaults to "desktopus".
 // Otherwise returns the configured user.
-func (d *DesktopConfig) EffectiveUser() string {
+func (d *ImageConfig) EffectiveUser() string {
 	if d.User == "" {
 		return "desktopus"
 	}
@@ -31,7 +30,7 @@ func (d *DesktopConfig) EffectiveUser() string {
 // If user is "abc", returns "/config" (the built-in linuxserver/webtop home).
 // If home is explicitly set, returns that value.
 // Otherwise returns "/home/<effective-user>".
-func (d *DesktopConfig) EffectiveHome() string {
+func (d *ImageConfig) EffectiveHome() string {
 	if d.User == "abc" {
 		return "/config"
 	}
@@ -113,21 +112,21 @@ type FileSpec struct {
 	Mode    string `yaml:"mode,omitempty"` // default "0644"
 }
 
-// RuntimeSpec defines container runtime configuration
-type RuntimeSpec struct {
+// RuntimeConfig defines container runtime configuration (desktopus.runtime.yaml)
+type RuntimeConfig struct {
 	Hostname string            `yaml:"hostname,omitempty"`
 	ShmSize  string            `yaml:"shm_size,omitempty"`
-	Ports    []string          `yaml:"ports,omitempty"`    // "host:container"
-	Volumes  []string          `yaml:"volumes,omitempty"`  // "host:container[:ro]"
+	Ports    []string          `yaml:"ports,omitempty"`   // "host:container"
+	Volumes  []string          `yaml:"volumes,omitempty"` // "host:container[:ro]"
 	GPU      bool              `yaml:"gpu,omitempty"`
 	Memory   string            `yaml:"memory,omitempty"`
 	CPUs     int               `yaml:"cpus,omitempty"`
-	Restart  string            `yaml:"restart,omitempty"`  // no | always | unless-stopped
+	Restart  string            `yaml:"restart,omitempty"` // no | always | unless-stopped
 	Network  string            `yaml:"network,omitempty"`
 	Env      map[string]string `yaml:"env,omitempty"`
 }
 
 // ImageTag returns the desktopus image tag for this desktop
-func (d *DesktopConfig) ImageTag() string {
+func (d *ImageConfig) ImageTag() string {
 	return fmt.Sprintf("desktopus/%s:latest", d.Name)
 }

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -8,29 +8,29 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// LoadDesktop reads and parses a desktopus.yaml file
-func LoadDesktop(path string) (*DesktopConfig, error) {
+// LoadImage reads and parses a desktopus.yaml file
+func LoadImage(path string) (*ImageConfig, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("reading desktop config: %w", err)
+		return nil, fmt.Errorf("reading image config: %w", err)
 	}
 
-	var cfg DesktopConfig
+	var cfg ImageConfig
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		return nil, fmt.Errorf("parsing desktop config: %w", err)
+		return nil, fmt.Errorf("parsing image config: %w", err)
 	}
 
-	if err := ValidateDesktop(&cfg); err != nil {
+	if err := ValidateImage(&cfg); err != nil {
 		return nil, err
 	}
 
 	return &cfg, nil
 }
 
-// FindDesktopConfig looks for desktopus.yaml in the given directory or path.
+// FindImageConfig looks for desktopus.yaml in the given directory or path.
 // If path is a directory, it looks for desktopus.yaml inside it.
 // If path is a file, it uses it directly.
-func FindDesktopConfig(path string) (string, error) {
+func FindImageConfig(path string) (string, error) {
 	info, err := os.Stat(path)
 	if err != nil {
 		return "", fmt.Errorf("accessing path %q: %w", path, err)
@@ -45,6 +45,36 @@ func FindDesktopConfig(path string) (string, error) {
 	}
 
 	return path, nil
+}
+
+// LoadRuntime reads and parses a desktopus.runtime.yaml file.
+// Returns a zero-value RuntimeConfig if the file does not exist.
+func LoadRuntime(path string) (*RuntimeConfig, error) {
+	var cfg RuntimeConfig
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &cfg, nil
+		}
+		return nil, fmt.Errorf("reading runtime config: %w", err)
+	}
+
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing runtime config: %w", err)
+	}
+
+	if err := ValidateRuntime(&cfg); err != nil {
+		return nil, err
+	}
+
+	return &cfg, nil
+}
+
+// FindRuntimeConfig returns the path to desktopus.runtime.yaml alongside the
+// given image config path. The file may or may not exist.
+func FindRuntimeConfig(imageConfigPath string) string {
+	return filepath.Join(filepath.Dir(imageConfigPath), "desktopus.runtime.yaml")
 }
 
 // LoadApp reads and parses the app config file.

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -45,8 +45,8 @@ func sliceContains(slice []string, val string) bool {
 	return false
 }
 
-// ValidateDesktop checks a DesktopConfig for errors
-func ValidateDesktop(cfg *DesktopConfig) error {
+// ValidateImage checks an ImageConfig for errors
+func ValidateImage(cfg *ImageConfig) error {
 	var errs []string
 
 	if cfg.Name == "" {
@@ -114,5 +114,16 @@ func ValidateDesktop(cfg *DesktopConfig) error {
 		return fmt.Errorf("config validation failed:\n  - %s", strings.Join(errs, "\n  - "))
 	}
 
+	return nil
+}
+
+var validRestartPolicies = []string{"no", "always", "unless-stopped", "on-failure"}
+
+// ValidateRuntime checks a RuntimeConfig for errors
+func ValidateRuntime(cfg *RuntimeConfig) error {
+	if cfg.Restart != "" && !sliceContains(validRestartPolicies, cfg.Restart) {
+		return fmt.Errorf("config validation failed:\n  - restart %q is not valid (valid: %s)",
+			cfg.Restart, strings.Join(validRestartPolicies, ", "))
+	}
 	return nil
 }

--- a/modules/integration_test.go
+++ b/modules/integration_test.go
@@ -52,7 +52,7 @@ func TestBuildModule(t *testing.T) {
 				t.Run(name, func(t *testing.T) {
 					imageTag := fmt.Sprintf("desktopus/test-%s-%s-%s:integration", mod.Name, os, desktop)
 
-					cfg := &config.DesktopConfig{
+					cfg := &config.ImageConfig{
 						Name: fmt.Sprintf("test-%s-%s-%s", mod.Name, os, desktop),
 						Base: config.BaseSpec{OS: os, Desktop: desktop},
 						Modules: []config.ModuleRef{


### PR DESCRIPTION
## Summary

- Separates build-time config (`desktopus.yaml`) from machine-local runtime config (`desktopus.runtime.yaml`), mirroring the `docker-compose.yml` + `docker-compose.override.yml` pattern
- `desktopus.runtime.yaml` is optional — `desktopus run` works without it using zero-value defaults
- `desktopus init` now scaffolds both files

## Changes

- Rename `DesktopConfig` → `ImageConfig`, `RuntimeSpec` → `RuntimeConfig` (promoted to top-level)
- Add `LoadRuntime` / `FindRuntimeConfig` loaders (no error if file absent)
- Add `ValidateRuntime` for restart policy validation
- `desktopus build` uses `LoadImage` only (runtime config is irrelevant at build time)
- `desktopus run` loads both configs; runtime env merges over image env defaults, CLI `--env` overrides both
- All references updated in build pipeline, tests, and integration tests