### PR TITLE
feat: add default_image to runtime config, desktopus run reads only runtime yaml

### DIFF
--- a/internal/build/pipeline.go
+++ b/internal/build/pipeline.go
@@ -113,13 +113,8 @@ func (p *Pipeline) Build(ctx context.Context, cfg *config.ImageConfig, configDir
 	}
 
 	// 8. Build image via Docker SDK
-	imageTag := cfg.ImageTag()
-	if opts.Tag != "" {
-		imageTag = opts.Tag
-	}
-
 	resp, err := p.docker.ImageBuild(ctx, reader, client.ImageBuildOptions{
-		Tags:       []string{imageTag},
+		Tags:       []string{opts.Tag},
 		Dockerfile: "Dockerfile",
 		Remove:     true,
 		NoCache:    opts.NoCache,

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -42,6 +42,17 @@ var buildCmd = &cobra.Command{
 			return err
 		}
 
+		runtimePath := config.FindRuntimeConfig(configPath)
+		rt, err := config.LoadRuntime(runtimePath)
+		if err != nil {
+			return err
+		}
+
+		imageTag, err := config.ResolveImageTag(rt, buildTag)
+		if err != nil {
+			return err
+		}
+
 		configDir := filepath.Dir(configPath)
 
 		// Create Docker client
@@ -60,7 +71,7 @@ var buildCmd = &cobra.Command{
 		// Run build
 		pipeline := build.NewPipeline(dockerClient, registry)
 		opts := build.Options{
-			Tag:              buildTag,
+			Tag:              imageTag,
 			NoCache:          buildNoCache,
 			AnsibleVerbosity: appConfig.Build.AnsibleVerbosity,
 		}
@@ -81,17 +92,13 @@ var buildCmd = &cobra.Command{
 			return fmt.Errorf("build failed: %w", err)
 		}
 
-		tag := cfg.ImageTag()
-		if buildTag != "" {
-			tag = buildTag
-		}
-		fmt.Printf("\nBuild complete: %s\n", tag)
+		fmt.Printf("\nBuild complete: %s\n", imageTag)
 		return nil
 	},
 }
 
 func init() {
-	buildCmd.Flags().StringVar(&buildTag, "tag", "", "override image tag")
+	buildCmd.Flags().StringVarP(&buildTag, "tag", "t", "", "override image tag")
 	buildCmd.Flags().BoolVar(&buildNoCache, "no-cache", false, "build without Docker cache")
 }
 

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -44,7 +44,7 @@ var initCmd = &cobra.Command{
 		}
 
 		runtimePath := filepath.Join(dir, "desktopus.runtime.yaml")
-		if err := os.WriteFile(runtimePath, []byte(generateRuntimeYAML()), 0644); err != nil {
+		if err := os.WriteFile(runtimePath, []byte(generateRuntimeYAML(name)), 0644); err != nil {
 			return fmt.Errorf("writing desktopus.runtime.yaml: %w", err)
 		}
 
@@ -54,7 +54,7 @@ var initCmd = &cobra.Command{
 		fmt.Printf("  1. Edit desktopus.yaml to customize your desktop\n")
 		fmt.Printf("  2. Edit desktopus.runtime.yaml for machine-local settings (ports, volumes, GPU)\n")
 		fmt.Printf("  3. Run: desktopus build .\n")
-		fmt.Printf("  4. Run: desktopus run %s\n", name)
+		fmt.Printf("  4. Run: desktopus run\n")
 		return nil
 	},
 }
@@ -89,8 +89,10 @@ modules:
 `, name, osName, desktop)
 }
 
-func generateRuntimeYAML() string {
-	return `shm_size: 2g
+func generateRuntimeYAML(name string) string {
+	return fmt.Sprintf(`name: %s
+default_image: desktopus/%s:latest
+shm_size: 2g
 ports:
   - "3000:3000"
   - "3001:3001"
@@ -101,5 +103,5 @@ env:
   PUID: "1000"
   PGID: "1000"
   TZ: UTC
-`
+`, name, name)
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -24,35 +25,29 @@ var (
 )
 
 var runCmd = &cobra.Command{
-	Use:   "run [name]",
+	Use:   "run [image]",
 	Short: "Run a desktop container",
 	Long:  "Create and start a container from a built desktop image.",
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// Find config file
-		file := runFile
-		if file == "" {
-			file = "."
+		var imageOverride string
+		if len(args) > 0 {
+			imageOverride = args[0]
 		}
 
-		configPath, err := config.FindImageConfig(file)
+		// Find desktopus.runtime.yaml
+		runtimePath, err := findRuntimeYAML(runFile)
 		if err != nil {
 			return err
 		}
 
-		img, err := config.LoadImage(configPath)
-		if err != nil {
-			return err
-		}
-
-		runtimePath := config.FindRuntimeConfig(configPath)
 		rt, err := config.LoadRuntime(runtimePath)
 		if err != nil {
 			return err
 		}
 
-		// Validate required env vars
-		if err := validateRequiredEnv(img, rt, runEnvs); err != nil {
+		imageTag, err := config.ResolveImageTag(rt, imageOverride)
+		if err != nil {
 			return err
 		}
 
@@ -84,17 +79,16 @@ var runCmd = &cobra.Command{
 			Remove:  runRemove,
 		}
 
-		// Build the runtime config from the image and runtime configs
-		runCfg := toDesktopRunConfig(img, rt)
+		runCfg := toDesktopRunConfig(rt, imageTag)
 
 		containerID, err := mgr.Run(context.Background(), runCfg, opts, os.Stdout)
 		if err != nil {
 			return fmt.Errorf("failed to run desktop: %w", err)
 		}
 
-		fmt.Printf("Desktop %q running (container: %s)\n", img.Name, containerID[:12])
+		name := runCfg.Name
+		fmt.Printf("Desktop %q running (container: %s)\n", name, containerID[:12])
 
-		// Find the web port
 		webPort := findWebPort(rt)
 		if webPort != "" {
 			fmt.Printf("  Web: http://localhost:%s\n", webPort)
@@ -105,7 +99,7 @@ var runCmd = &cobra.Command{
 }
 
 func init() {
-	runCmd.Flags().StringVarP(&runFile, "file", "f", "", "path to desktopus.yaml")
+	runCmd.Flags().StringVarP(&runFile, "file", "f", "", "path to desktopus.runtime.yaml or its directory")
 	runCmd.Flags().BoolVarP(&runDetach, "detach", "d", true, "run in background")
 	runCmd.Flags().BoolVar(&runGPU, "gpu", false, "enable GPU passthrough")
 	runCmd.Flags().StringArrayVar(&runPorts, "port", nil, "additional port mappings (host:container)")
@@ -115,40 +109,38 @@ func init() {
 	runCmd.Flags().BoolVar(&runRemove, "rm", false, "remove container when stopped")
 }
 
-func validateRequiredEnv(img *config.ImageConfig, rt *config.RuntimeConfig, cliEnvs []string) error {
-	provided := make(map[string]bool)
-
-	// From defaults
-	for name, spec := range img.Env {
-		if spec.Default != "" {
-			provided[name] = true
-		}
+// findRuntimeYAML resolves the path to desktopus.runtime.yaml.
+// If path is empty or a directory, it looks for desktopus.runtime.yaml inside it.
+// If path is a file, it uses it directly.
+func findRuntimeYAML(path string) (string, error) {
+	if path == "" {
+		path = "."
 	}
 
-	// From runtime env
-	for k := range rt.Env {
-		provided[k] = true
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", fmt.Errorf("accessing path %q: %w", path, err)
 	}
 
-	// From CLI
-	for _, e := range cliEnvs {
-		parts := strings.SplitN(e, "=", 2)
-		if len(parts) >= 1 {
-			provided[parts[0]] = true
-		}
+	if info.IsDir() {
+		return filepath.Join(path, "desktopus.runtime.yaml"), nil
 	}
 
-	var missing []string
-	for name, spec := range img.Env {
-		if spec.Required && !provided[name] {
-			missing = append(missing, name)
-		}
-	}
+	return path, nil
+}
 
-	if len(missing) > 0 {
-		return fmt.Errorf("required environment variables not set: %s\nUse --env KEY=VALUE to provide them", strings.Join(missing, ", "))
+// containerNameFromImage derives a container name from an image tag.
+// "registry.example.com/mydesk:v1" → "mydesk"
+// "desktopus/mydesk:latest" → "mydesk"
+func containerNameFromImage(image string) string {
+	name := image
+	if i := strings.LastIndex(name, "/"); i >= 0 {
+		name = name[i+1:]
 	}
-	return nil
+	if i := strings.Index(name, ":"); i >= 0 {
+		name = name[:i]
+	}
+	return name
 }
 
 func findWebPort(rt *config.RuntimeConfig) string {
@@ -161,21 +153,21 @@ func findWebPort(rt *config.RuntimeConfig) string {
 	return ""
 }
 
-// toDesktopRunConfig converts ImageConfig + RuntimeConfig into a runtime DesktopRunConfig
-func toDesktopRunConfig(img *config.ImageConfig, rt *config.RuntimeConfig) *runtime.DesktopRunConfig {
-	env := make(map[string]string)
-	for name, spec := range img.Env {
-		if spec.Default != "" {
-			env[name] = spec.Default
-		}
+// toDesktopRunConfig builds a DesktopRunConfig from the runtime config and resolved image tag.
+func toDesktopRunConfig(rt *config.RuntimeConfig, imageTag string) *runtime.DesktopRunConfig {
+	name := rt.Name
+	if name == "" {
+		name = containerNameFromImage(imageTag)
 	}
+
+	env := make(map[string]string)
 	for k, v := range rt.Env {
 		env[k] = v
 	}
 
 	return &runtime.DesktopRunConfig{
-		Name:     img.Name,
-		ImageTag: img.ImageTag(),
+		Name:     name,
+		ImageTag: imageTag,
 		Hostname: rt.Hostname,
 		ShmSize:  rt.ShmSize,
 		Ports:    rt.Ports,

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -1,0 +1,154 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/desktopus-org/desktopus/internal/config"
+	"github.com/desktopus-org/desktopus/internal/runtime"
+)
+
+// --- containerNameFromImage ---
+
+func TestContainerNameFromImage(t *testing.T) {
+	tests := []struct {
+		image string
+		want  string
+	}{
+		{"desktopus/mydesk:latest", "mydesk"},
+		{"mydesk:latest", "mydesk"},
+		{"mydesk", "mydesk"},
+		{"registry.example.com/mydesk:v1", "mydesk"},
+		{"registry.example.com/org/mydesk:v1", "mydesk"},
+	}
+	for _, tt := range tests {
+		got := containerNameFromImage(tt.image)
+		if got != tt.want {
+			t.Errorf("containerNameFromImage(%q) = %q, want %q", tt.image, got, tt.want)
+		}
+	}
+}
+
+// --- findRuntimeYAML ---
+
+func TestFindRuntimeYAMLFromDir(t *testing.T) {
+	dir := t.TempDir()
+	got, err := findRuntimeYAML(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(dir, "desktopus.runtime.yaml")
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFindRuntimeYAMLFromFile(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "custom.runtime.yaml")
+	if err := os.WriteFile(file, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := findRuntimeYAML(file)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != file {
+		t.Errorf("got %q, want %q", got, file)
+	}
+}
+
+func TestFindRuntimeYAMLEmpty(t *testing.T) {
+	dir := t.TempDir()
+	got, err := findRuntimeYAML("")
+	if err != nil {
+		t.Fatalf("empty path should use '.', got error: %v", err)
+	}
+	// Should resolve to desktopus.runtime.yaml in the working directory
+	want := "desktopus.runtime.yaml"
+	if filepath.Base(got) != want {
+		t.Errorf("got base %q, want %q (full: %q, dir: %q)", filepath.Base(got), want, got, dir)
+	}
+}
+
+func TestFindRuntimeYAMLBadPath(t *testing.T) {
+	_, err := findRuntimeYAML("/nonexistent/path")
+	if err == nil {
+		t.Error("expected error for nonexistent path")
+	}
+}
+
+// --- toDesktopRunConfig ---
+
+func TestToDesktopRunConfigUsesRuntimeName(t *testing.T) {
+	rt := &config.RuntimeConfig{
+		Name:     "mydesk",
+		ShmSize:  "2g",
+		Env:      map[string]string{"TZ": "UTC"},
+	}
+	cfg := toDesktopRunConfig(rt, "desktopus/mydesk:latest")
+	if cfg.Name != "mydesk" {
+		t.Errorf("expected name 'mydesk', got %q", cfg.Name)
+	}
+}
+
+func TestToDesktopRunConfigDerivesNameFromImage(t *testing.T) {
+	rt := &config.RuntimeConfig{ShmSize: "2g"}
+	cfg := toDesktopRunConfig(rt, "desktopus/mydesk:latest")
+	if cfg.Name != "mydesk" {
+		t.Errorf("expected name derived from image 'mydesk', got %q", cfg.Name)
+	}
+}
+
+func TestToDesktopRunConfigSetsImageTag(t *testing.T) {
+	rt := &config.RuntimeConfig{}
+	cfg := toDesktopRunConfig(rt, "registry.example.com/desk:v1")
+	if cfg.ImageTag != "registry.example.com/desk:v1" {
+		t.Errorf("expected ImageTag 'registry.example.com/desk:v1', got %q", cfg.ImageTag)
+	}
+}
+
+func TestToDesktopRunConfigMapsRuntimeFields(t *testing.T) {
+	rt := &config.RuntimeConfig{
+		Hostname: "myhost",
+		ShmSize:  "4g",
+		Ports:    []string{"3000:3000"},
+		Volumes:  []string{"~/projects:/config/projects"},
+		GPU:      true,
+		Memory:   "8g",
+		CPUs:     4,
+		Restart:  "unless-stopped",
+		Network:  "host",
+		Env:      map[string]string{"TZ": "UTC", "PUID": "1000"},
+	}
+	cfg := toDesktopRunConfig(rt, "mydesk:latest")
+
+	checks := []struct {
+		name string
+		got  interface{}
+		want interface{}
+	}{
+		{"Hostname", cfg.Hostname, "myhost"},
+		{"ShmSize", cfg.ShmSize, "4g"},
+		{"GPU", cfg.GPU, true},
+		{"Memory", cfg.Memory, "8g"},
+		{"CPUs", cfg.CPUs, 4},
+		{"Restart", cfg.Restart, "unless-stopped"},
+		{"Network", cfg.Network, "host"},
+	}
+	for _, c := range checks {
+		if c.got != c.want {
+			t.Errorf("%s: got %v, want %v", c.name, c.got, c.want)
+		}
+	}
+	if len(cfg.Ports) != 1 || cfg.Ports[0] != "3000:3000" {
+		t.Errorf("Ports: got %v, want [3000:3000]", cfg.Ports)
+	}
+	if cfg.Env["TZ"] != "UTC" || cfg.Env["PUID"] != "1000" {
+		t.Errorf("Env: got %v", cfg.Env)
+	}
+}
+
+// verify toDesktopRunConfig returns the right type
+var _ *runtime.DesktopRunConfig = (*runtime.DesktopRunConfig)(nil)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -43,13 +43,48 @@ func TestImageRefCustomTag(t *testing.T) {
 	}
 }
 
-// --- ImageConfig.ImageTag ---
+// --- ResolveImageTag ---
 
-func TestImageTag(t *testing.T) {
-	cfg := ImageConfig{Name: "my-desktop"}
-	want := "desktopus/my-desktop:latest"
-	if got := cfg.ImageTag(); got != want {
-		t.Errorf("ImageTag() = %q, want %q", got, want)
+func TestResolveImageTagCLIOverride(t *testing.T) {
+	rt := &RuntimeConfig{DefaultImage: "desktopus/desk:latest"}
+	got, err := ResolveImageTag(rt, "myregistry.io/desk:override")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "myregistry.io/desk:override" {
+		t.Errorf("expected CLI override to win, got %q", got)
+	}
+}
+
+func TestResolveImageTagRuntimeDefault(t *testing.T) {
+	rt := &RuntimeConfig{DefaultImage: "registry.example.com/desk:v1"}
+	got, err := ResolveImageTag(rt, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "registry.example.com/desk:v1" {
+		t.Errorf("expected runtime default_image, got %q", got)
+	}
+}
+
+func TestResolveImageTagNilRuntime(t *testing.T) {
+	_, err := ResolveImageTag(nil, "")
+	if err == nil {
+		t.Fatal("expected error for nil runtime with no override")
+	}
+	if !strings.Contains(err.Error(), "no image tag defined") {
+		t.Errorf("expected 'no image tag defined' error, got: %v", err)
+	}
+}
+
+func TestResolveImageTagError(t *testing.T) {
+	rt := &RuntimeConfig{}
+	_, err := ResolveImageTag(rt, "")
+	if err == nil {
+		t.Fatal("expected error when no image tag is defined")
+	}
+	if !strings.Contains(err.Error(), "no image tag defined") {
+		t.Errorf("expected 'no image tag defined' error, got: %v", err)
 	}
 }
 

--- a/internal/config/desktop.go
+++ b/internal/config/desktop.go
@@ -6,13 +6,13 @@ import "fmt"
 type ImageConfig struct {
 	Name        string            `yaml:"name"`
 	Description string            `yaml:"description,omitempty"`
-	User        string            `yaml:"user,omitempty"`
-	Home        string            `yaml:"home,omitempty"`
-	Base        BaseSpec          `yaml:"base"`
-	Modules     []ModuleRef       `yaml:"modules,omitempty"`
-	Env         map[string]EnvVar `yaml:"env,omitempty"`
-	PostRun     []PostRunScript   `yaml:"postrun,omitempty"`
-	Files       []FileSpec        `yaml:"files,omitempty"`
+	User         string            `yaml:"user,omitempty"`
+	Home         string            `yaml:"home,omitempty"`
+	Base         BaseSpec          `yaml:"base"`
+	Modules      []ModuleRef       `yaml:"modules,omitempty"`
+	Env          map[string]EnvVar `yaml:"env,omitempty"`
+	PostRun      []PostRunScript   `yaml:"postrun,omitempty"`
+	Files        []FileSpec        `yaml:"files,omitempty"`
 }
 
 // EffectiveUser returns the resolved Linux username for this desktop.
@@ -114,7 +114,9 @@ type FileSpec struct {
 
 // RuntimeConfig defines container runtime configuration (desktopus.runtime.yaml)
 type RuntimeConfig struct {
-	Hostname string            `yaml:"hostname,omitempty"`
+	Name         string            `yaml:"name,omitempty"`
+	DefaultImage string            `yaml:"default_image,omitempty"`
+	Hostname     string            `yaml:"hostname,omitempty"`
 	ShmSize  string            `yaml:"shm_size,omitempty"`
 	Ports    []string          `yaml:"ports,omitempty"`   // "host:container"
 	Volumes  []string          `yaml:"volumes,omitempty"` // "host:container[:ro]"
@@ -126,7 +128,14 @@ type RuntimeConfig struct {
 	Env      map[string]string `yaml:"env,omitempty"`
 }
 
-// ImageTag returns the desktopus image tag for this desktop
-func (d *ImageConfig) ImageTag() string {
-	return fmt.Sprintf("desktopus/%s:latest", d.Name)
+// ResolveImageTag resolves the Docker image tag in priority order:
+// override (CLI flag) > rt.DefaultImage > error
+func ResolveImageTag(rt *RuntimeConfig, override string) (string, error) {
+	if override != "" {
+		return override, nil
+	}
+	if rt != nil && rt.DefaultImage != "" {
+		return rt.DefaultImage, nil
+	}
+	return "", fmt.Errorf("no image tag defined: set default_image in desktopus.runtime.yaml, or specify it explicitly")
 }


### PR DESCRIPTION
## Summary

- `default_image` is now defined in `desktopus.runtime.yaml` (runtime/deployment concern) — removed from `desktopus.yaml`
- `desktopus run` reads **only** `desktopus.runtime.yaml`; no longer depends on `desktopus.yaml`
- `desktopus run [image]` accepts the image as an optional positional argument (overrides `default_image`)
- `desktopus build` gains `-t` shorthand for `--tag`
- `desktopus.runtime.yaml` gains `name` and `default_image` fields, both emitted by `desktopus init`
- `ResolveImageTag` simplified: priority is CLI arg > `rt.DefaultImage` > error
- Fails with a clear error if no image tag is defined anywhere