### PR TITLE
fix: move default_image to desktopus.yaml

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ desktopus.yaml → resolve modules → check compatibility
 - **Container labels**: `org.desktopus.managed-by=desktopus` and `org.desktopus.desktop=<name>` used to filter desktopus-managed containers.
 - **Config validation**: Uses a compatibility matrix — each OS (`ubuntu|debian|fedora|arch|alpine|el`) maps to its valid desktops (`i3|kde|mate|xfce`; EL has no KDE).
 - **Version injection**: `main.go` has `var version, commit, buildTime` set via ldflags in `magefile.go`.
-- **Image tagging**: `desktopus/<name>:<tag>` (default tag: `latest`).
+- **Image tagging**: `desktopus build` reads `image` from `desktopus.yaml` only (`--tag` overrides). `desktopus run` reads `image` from `desktopus.runtime.yaml` only (CLI arg overrides). Each command is independent — fails if no image is provided.
 
 ## Plan Documents
 

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -42,13 +42,7 @@ var buildCmd = &cobra.Command{
 			return err
 		}
 
-		runtimePath := config.FindRuntimeConfig(configPath)
-		rt, err := config.LoadRuntime(runtimePath)
-		if err != nil {
-			return err
-		}
-
-		imageTag, err := config.ResolveImageTag(rt, buildTag)
+		imageTag, err := config.ResolveImageTag(cfg.Image, buildTag)
 		if err != nil {
 			return err
 		}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -91,7 +91,7 @@ modules:
 
 func generateRuntimeYAML(name string) string {
 	return fmt.Sprintf(`name: %s
-default_image: desktopus/%s:latest
+# default_image: myregistry/my-image:latest
 shm_size: 2g
 ports:
   - "3000:3000"
@@ -103,5 +103,5 @@ env:
   PUID: "1000"
   PGID: "1000"
   TZ: UTC
-`, name, name)
+`, name)
 }

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -68,6 +68,7 @@ func init() {
 func generateImageYAML(name, osName, desktop string) string {
 	return fmt.Sprintf(`name: %s
 description: "My desktop environment"
+image: %s:latest
 
 base:
   os: %s
@@ -86,12 +87,11 @@ modules:
 #     runas: abc
 #     script: |
 #       echo "Hello from post-run script"
-`, name, osName, desktop)
+`, name, name, osName, desktop)
 }
 
 func generateRuntimeYAML(name string) string {
 	return fmt.Sprintf(`name: %s
-# default_image: myregistry/my-image:latest
 shm_size: 2g
 ports:
   - "3000:3000"

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -46,7 +46,7 @@ var runCmd = &cobra.Command{
 			return err
 		}
 
-		imageTag, err := config.ResolveImageTag(rt, imageOverride)
+		imageTag, err := config.ResolveImageTag(rt.Image, imageOverride)
 		if err != nil {
 			return err
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -46,8 +46,7 @@ func TestImageRefCustomTag(t *testing.T) {
 // --- ResolveImageTag ---
 
 func TestResolveImageTagCLIOverride(t *testing.T) {
-	rt := &RuntimeConfig{DefaultImage: "desktopus/desk:latest"}
-	got, err := ResolveImageTag(rt, "myregistry.io/desk:override")
+	got, err := ResolveImageTag("desk:latest", "myregistry.io/desk:override")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -56,35 +55,23 @@ func TestResolveImageTagCLIOverride(t *testing.T) {
 	}
 }
 
-func TestResolveImageTagRuntimeDefault(t *testing.T) {
-	rt := &RuntimeConfig{DefaultImage: "registry.example.com/desk:v1"}
-	got, err := ResolveImageTag(rt, "")
+func TestResolveImageTagFromConfig(t *testing.T) {
+	got, err := ResolveImageTag("registry.example.com/desk:v1", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if got != "registry.example.com/desk:v1" {
-		t.Errorf("expected runtime default_image, got %q", got)
+		t.Errorf("expected config image, got %q", got)
 	}
 }
 
-func TestResolveImageTagNilRuntime(t *testing.T) {
-	_, err := ResolveImageTag(nil, "")
+func TestResolveImageTagNoImage(t *testing.T) {
+	_, err := ResolveImageTag("", "")
 	if err == nil {
-		t.Fatal("expected error for nil runtime with no override")
+		t.Fatal("expected error when no image is defined")
 	}
-	if !strings.Contains(err.Error(), "no image tag defined") {
-		t.Errorf("expected 'no image tag defined' error, got: %v", err)
-	}
-}
-
-func TestResolveImageTagError(t *testing.T) {
-	rt := &RuntimeConfig{}
-	_, err := ResolveImageTag(rt, "")
-	if err == nil {
-		t.Fatal("expected error when no image tag is defined")
-	}
-	if !strings.Contains(err.Error(), "no image tag defined") {
-		t.Errorf("expected 'no image tag defined' error, got: %v", err)
+	if !strings.Contains(err.Error(), "no image defined") {
+		t.Errorf("expected 'no image defined' error, got: %v", err)
 	}
 }
 

--- a/internal/config/desktop.go
+++ b/internal/config/desktop.go
@@ -6,13 +6,14 @@ import "fmt"
 type ImageConfig struct {
 	Name        string            `yaml:"name"`
 	Description string            `yaml:"description,omitempty"`
-	User         string            `yaml:"user,omitempty"`
-	Home         string            `yaml:"home,omitempty"`
-	Base         BaseSpec          `yaml:"base"`
-	Modules      []ModuleRef       `yaml:"modules,omitempty"`
-	Env          map[string]EnvVar `yaml:"env,omitempty"`
-	PostRun      []PostRunScript   `yaml:"postrun,omitempty"`
-	Files        []FileSpec        `yaml:"files,omitempty"`
+	Image       string            `yaml:"image,omitempty"`
+	User        string            `yaml:"user,omitempty"`
+	Home        string            `yaml:"home,omitempty"`
+	Base        BaseSpec          `yaml:"base"`
+	Modules     []ModuleRef       `yaml:"modules,omitempty"`
+	Env         map[string]EnvVar `yaml:"env,omitempty"`
+	PostRun     []PostRunScript   `yaml:"postrun,omitempty"`
+	Files       []FileSpec        `yaml:"files,omitempty"`
 }
 
 // EffectiveUser returns the resolved Linux username for this desktop.
@@ -114,9 +115,9 @@ type FileSpec struct {
 
 // RuntimeConfig defines container runtime configuration (desktopus.runtime.yaml)
 type RuntimeConfig struct {
-	Name         string            `yaml:"name,omitempty"`
-	DefaultImage string            `yaml:"default_image,omitempty"`
-	Hostname     string            `yaml:"hostname,omitempty"`
+	Name     string            `yaml:"name,omitempty"`
+	Image    string            `yaml:"image,omitempty"` // overrides desktopus.yaml image for this machine
+	Hostname string            `yaml:"hostname,omitempty"`
 	ShmSize  string            `yaml:"shm_size,omitempty"`
 	Ports    []string          `yaml:"ports,omitempty"`   // "host:container"
 	Volumes  []string          `yaml:"volumes,omitempty"` // "host:container[:ro]"
@@ -129,13 +130,13 @@ type RuntimeConfig struct {
 }
 
 // ResolveImageTag resolves the Docker image tag in priority order:
-// override (CLI flag) > rt.DefaultImage > error
-func ResolveImageTag(rt *RuntimeConfig, override string) (string, error) {
+// override (CLI flag) > image (from config file) > error
+func ResolveImageTag(image, override string) (string, error) {
 	if override != "" {
 		return override, nil
 	}
-	if rt != nil && rt.DefaultImage != "" {
-		return rt.DefaultImage, nil
+	if image != "" {
+		return image, nil
 	}
-	return "", fmt.Errorf("no image tag defined: set default_image in desktopus.runtime.yaml, or specify it explicitly")
+	return "", fmt.Errorf("no image defined: set image in the config file, or specify it explicitly")
 }


### PR DESCRIPTION
## Summary

- Renamed `default_image` to `image` in both `desktopus.yaml` and `desktopus.runtime.yaml`
- `desktopus build` reads `image` from `desktopus.yaml` only — fails if not set (or `--tag` overrides)
- `desktopus run` reads `image` from `desktopus.runtime.yaml` only — fails if not set (or CLI arg overrides)
- The two commands are fully independent; no cross-reading between config files
- `desktopus init` scaffold places `image` in `desktopus.yaml`; runtime yaml has no `image` entry by default