### PR TITLE
feat: multi-provider runtime abstraction

### DIFF
--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -20,13 +20,13 @@ var listCmd = &cobra.Command{
 	Aliases: []string{"ls"},
 	Short:   "List desktop containers",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		dockerClient, err := newDockerClient()
+		provider, err := runtime.NewProvider("")
 		if err != nil {
 			return err
 		}
-		defer func() { _ = dockerClient.Close() }()
+		defer func() { _ = provider.Close() }()
 
-		mgr := runtime.NewManager(dockerClient)
+		mgr := runtime.NewManager(provider)
 		containers, err := mgr.List(context.Background(), listAll)
 		if err != nil {
 			return err

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -51,14 +51,13 @@ var runCmd = &cobra.Command{
 			return err
 		}
 
-		// Create Docker client
-		dockerClient, err := newDockerClient()
+		provider, err := runtime.NewProvider(rt.Provider)
 		if err != nil {
 			return err
 		}
-		defer func() { _ = dockerClient.Close() }()
+		defer func() { _ = provider.Close() }()
 
-		mgr := runtime.NewManager(dockerClient)
+		mgr := runtime.NewManager(provider)
 
 		// Parse CLI env vars
 		envMap := make(map[string]string)

--- a/internal/cli/stop.go
+++ b/internal/cli/stop.go
@@ -23,13 +23,13 @@ var stopCmd = &cobra.Command{
 			return fmt.Errorf("specify container name(s) or use --all")
 		}
 
-		dockerClient, err := newDockerClient()
+		provider, err := runtime.NewProvider("")
 		if err != nil {
 			return err
 		}
-		defer func() { _ = dockerClient.Close() }()
+		defer func() { _ = provider.Close() }()
 
-		mgr := runtime.NewManager(dockerClient)
+		mgr := runtime.NewManager(provider)
 		ctx := context.Background()
 
 		if stopAll {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -577,6 +577,37 @@ func TestValidateRuntimeInvalidRestart(t *testing.T) {
 	}
 }
 
+func TestValidateRuntimeValidProvider(t *testing.T) {
+	for _, p := range []string{"", "docker"} {
+		cfg := &RuntimeConfig{Provider: p}
+		if err := ValidateRuntime(cfg); err != nil {
+			t.Errorf("provider %q should be valid: %v", p, err)
+		}
+	}
+}
+
+func TestValidateRuntimeInvalidProvider(t *testing.T) {
+	cfg := &RuntimeConfig{Provider: "podman"}
+	err := ValidateRuntime(cfg)
+	if err == nil {
+		t.Error("expected error for unsupported provider")
+	}
+	if !strings.Contains(err.Error(), "provider") {
+		t.Errorf("expected 'provider' in error, got: %v", err)
+	}
+}
+
+func TestValidateRuntimeMultipleErrors(t *testing.T) {
+	cfg := &RuntimeConfig{Restart: "bad", Provider: "podman"}
+	err := ValidateRuntime(cfg)
+	if err == nil {
+		t.Fatal("expected errors")
+	}
+	if strings.Count(err.Error(), "\n") < 1 {
+		t.Errorf("expected multiple errors, got: %v", err)
+	}
+}
+
 // --- LoadApp ---
 
 func TestLoadAppDefaults(t *testing.T) {

--- a/internal/config/desktop.go
+++ b/internal/config/desktop.go
@@ -127,6 +127,7 @@ type RuntimeConfig struct {
 	Restart  string            `yaml:"restart,omitempty"` // no | always | unless-stopped
 	Network  string            `yaml:"network,omitempty"`
 	Env      map[string]string `yaml:"env,omitempty"`
+	Provider string            `yaml:"provider,omitempty"` // container runtime provider (default: docker)
 }
 
 // ResolveImageTag resolves the Docker image tag in priority order:

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -118,12 +118,24 @@ func ValidateImage(cfg *ImageConfig) error {
 }
 
 var validRestartPolicies = []string{"no", "always", "unless-stopped", "on-failure"}
+var validProviders = []string{"docker"}
 
 // ValidateRuntime checks a RuntimeConfig for errors
 func ValidateRuntime(cfg *RuntimeConfig) error {
+	var errs []string
+
 	if cfg.Restart != "" && !sliceContains(validRestartPolicies, cfg.Restart) {
-		return fmt.Errorf("config validation failed:\n  - restart %q is not valid (valid: %s)",
-			cfg.Restart, strings.Join(validRestartPolicies, ", "))
+		errs = append(errs, fmt.Sprintf("restart %q is not valid (valid: %s)",
+			cfg.Restart, strings.Join(validRestartPolicies, ", ")))
+	}
+
+	if cfg.Provider != "" && !sliceContains(validProviders, cfg.Provider) {
+		errs = append(errs, fmt.Sprintf("provider %q is not supported (valid: %s)",
+			cfg.Provider, strings.Join(validProviders, ", ")))
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("config validation failed:\n  - %s", strings.Join(errs, "\n  - "))
 	}
 	return nil
 }

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -1,0 +1,307 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/netip"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
+	"github.com/moby/moby/client"
+
+	"github.com/desktopus-org/desktopus/internal/progress"
+)
+
+// DockerProvider implements Provider using the Docker SDK.
+type DockerProvider struct {
+	docker *client.Client
+}
+
+// Close releases the underlying Docker client connection.
+func (d *DockerProvider) Close() error {
+	return d.docker.Close()
+}
+
+// Run creates and starts a container from a desktop config.
+// output receives pull progress if the image is not present locally.
+func (d *DockerProvider) Run(ctx context.Context, cfg *DesktopRunConfig, opts RunOptions, output io.Writer) (string, error) {
+	if err := d.pullIfMissing(ctx, cfg.ImageTag, output); err != nil {
+		return "", err
+	}
+
+	containerName := cfg.Name
+	if opts.Name != "" {
+		containerName = opts.Name
+	}
+
+	envList := buildEnvList(cfg, opts)
+	portBindings, exposedPorts, err := buildPortBindings(cfg, opts)
+	if err != nil {
+		return "", fmt.Errorf("configuring ports: %w", err)
+	}
+	binds := buildVolumes(cfg, opts)
+
+	shmSize := parseSize(cfg.ShmSize)
+	if opts.ShmSize != "" {
+		shmSize = parseSize(opts.ShmSize)
+	}
+
+	containerCfg := &container.Config{
+		Image:        cfg.ImageTag,
+		Hostname:     cfg.Hostname,
+		Env:          envList,
+		ExposedPorts: exposedPorts,
+		Labels: map[string]string{
+			LabelManagedBy: "desktopus",
+			LabelDesktop:   cfg.Name,
+		},
+	}
+
+	hostCfg := &container.HostConfig{
+		PortBindings: portBindings,
+		Binds:        binds,
+		ShmSize:      shmSize,
+		AutoRemove:   opts.Remove,
+	}
+
+	if cfg.Restart != "" && cfg.Restart != "no" {
+		hostCfg.RestartPolicy = container.RestartPolicy{Name: container.RestartPolicyMode(cfg.Restart)}
+	}
+
+	if cfg.Memory != "" {
+		if mem := parseSize(cfg.Memory); mem > 0 {
+			hostCfg.Memory = mem
+		}
+	}
+	if cfg.CPUs > 0 {
+		hostCfg.NanoCPUs = int64(cfg.CPUs) * 1e9
+	}
+
+	if cfg.GPU || opts.GPU {
+		hostCfg.Devices = append(hostCfg.Devices, container.DeviceMapping{
+			PathOnHost:        "/dev/dri",
+			PathInContainer:   "/dev/dri",
+			CgroupPermissions: "rwm",
+		})
+	}
+
+	if cfg.Network != "" {
+		hostCfg.NetworkMode = container.NetworkMode(cfg.Network)
+	}
+
+	resp, err := d.docker.ContainerCreate(ctx, client.ContainerCreateOptions{
+		Config:     containerCfg,
+		HostConfig: hostCfg,
+		Name:       containerName,
+	})
+	if err != nil {
+		return "", fmt.Errorf("creating container: %w", err)
+	}
+
+	if _, err := d.docker.ContainerStart(ctx, resp.ID, client.ContainerStartOptions{}); err != nil {
+		return "", fmt.Errorf("starting container: %w", err)
+	}
+
+	return resp.ID, nil
+}
+
+// Stop stops a container by name or ID.
+func (d *DockerProvider) Stop(ctx context.Context, nameOrID string, timeout int) error {
+	t := timeout
+	_, err := d.docker.ContainerStop(ctx, nameOrID, client.ContainerStopOptions{Timeout: &t})
+	return err
+}
+
+// Remove removes a container.
+func (d *DockerProvider) Remove(ctx context.Context, nameOrID string, force bool) error {
+	_, err := d.docker.ContainerRemove(ctx, nameOrID, client.ContainerRemoveOptions{Force: force})
+	return err
+}
+
+// List returns all desktopus-managed containers.
+func (d *DockerProvider) List(ctx context.Context, all bool) ([]ContainerInfo, error) {
+	f := make(client.Filters)
+	f.Add("label", LabelManagedBy+"=desktopus")
+
+	result, err := d.docker.ContainerList(ctx, client.ContainerListOptions{
+		All:     all,
+		Filters: f,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing containers: %w", err)
+	}
+
+	infos := make([]ContainerInfo, len(result.Items))
+	for i, c := range result.Items {
+		name := ""
+		if len(c.Names) > 0 {
+			name = strings.TrimPrefix(c.Names[0], "/")
+		}
+
+		ports := formatPorts(c.Ports)
+
+		infos[i] = ContainerInfo{
+			ID:      c.ID[:12],
+			Name:    name,
+			Desktop: c.Labels[LabelDesktop],
+			Image:   c.Image,
+			Status:  string(c.State),
+			State:   c.Status,
+			Ports:   ports,
+			Created: time.Unix(c.Created, 0),
+		}
+	}
+
+	return infos, nil
+}
+
+// pullIfMissing pulls the image if it is not already present locally.
+func (d *DockerProvider) pullIfMissing(ctx context.Context, image string, output io.Writer) error {
+	_, err := d.docker.ImageInspect(ctx, image)
+	if err == nil {
+		return nil
+	}
+
+	fmt.Fprintf(output, "Pulling %s...\n", image)
+	rc, err := d.docker.ImagePull(ctx, image, client.ImagePullOptions{})
+	if err != nil {
+		return fmt.Errorf("pulling image %s: %w", image, err)
+	}
+	defer func() { _ = rc.Close() }()
+
+	return streamPullOutput(rc, output)
+}
+
+func streamPullOutput(reader io.Reader, output io.Writer) error {
+	decoder := json.NewDecoder(reader)
+	pr := progress.New(output)
+	for {
+		var event struct {
+			Status   string `json:"status"`
+			Progress string `json:"progress"`
+			ID       string `json:"id"`
+			Error    string `json:"error"`
+		}
+		if err := decoder.Decode(&event); err != nil {
+			if err == io.EOF {
+				pr.Flush()
+				return nil
+			}
+			return err
+		}
+		if event.Error != "" {
+			pr.Clear()
+			return fmt.Errorf("%s", event.Error)
+		}
+		if event.Status == "" {
+			continue
+		}
+		if event.ID != "" {
+			pr.Update(event.ID, event.Status, event.Progress)
+		} else {
+			pr.Print(event.Status)
+		}
+	}
+}
+
+func buildEnvList(cfg *DesktopRunConfig, opts RunOptions) []string {
+	env := make(map[string]string)
+	for k, v := range cfg.Env {
+		env[k] = v
+	}
+	for k, v := range opts.Env {
+		env[k] = v
+	}
+
+	list := make([]string, 0, len(env))
+	for k, v := range env {
+		list = append(list, k+"="+v)
+	}
+	return list
+}
+
+func buildPortBindings(cfg *DesktopRunConfig, opts RunOptions) (network.PortMap, network.PortSet, error) {
+	portMap := network.PortMap{}
+	portSet := network.PortSet{}
+
+	allPorts := append(cfg.Ports, opts.Ports...)
+	for _, p := range allPorts {
+		parts := strings.SplitN(p, ":", 2)
+		if len(parts) != 2 {
+			return nil, nil, fmt.Errorf("invalid port mapping %q (expected host:container)", p)
+		}
+
+		containerPort, err := network.ParsePort(parts[1] + "/tcp")
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid container port %q: %w", parts[1], err)
+		}
+		portSet[containerPort] = struct{}{}
+		portMap[containerPort] = []network.PortBinding{
+			{HostIP: netip.MustParseAddr("0.0.0.0"), HostPort: parts[0]},
+		}
+	}
+
+	return portMap, portSet, nil
+}
+
+func buildVolumes(cfg *DesktopRunConfig, opts RunOptions) []string {
+	allVolumes := append(cfg.Volumes, opts.Volumes...)
+
+	binds := make([]string, 0, len(allVolumes))
+	for _, v := range allVolumes {
+		if strings.HasPrefix(v, "~/") {
+			if home, err := os.UserHomeDir(); err == nil {
+				v = home + v[1:]
+			}
+		}
+		binds = append(binds, v)
+	}
+	return binds
+}
+
+func parseSize(s string) int64 {
+	if s == "" {
+		return 0
+	}
+	s = strings.TrimSpace(strings.ToLower(s))
+	multiplier := int64(1)
+
+	if strings.HasSuffix(s, "g") {
+		multiplier = 1024 * 1024 * 1024
+		s = strings.TrimSuffix(s, "g")
+	} else if strings.HasSuffix(s, "m") {
+		multiplier = 1024 * 1024
+		s = strings.TrimSuffix(s, "m")
+	} else if strings.HasSuffix(s, "k") {
+		multiplier = 1024
+		s = strings.TrimSuffix(s, "k")
+	}
+
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return n * multiplier
+}
+
+func formatPorts(ports []container.PortSummary) string {
+	if len(ports) == 0 {
+		return "-"
+	}
+	parts := make([]string, 0, len(ports))
+	for _, p := range ports {
+		if p.PublicPort > 0 {
+			parts = append(parts, fmt.Sprintf("%s:%d->%d/%s", p.IP.String(), p.PublicPort, p.PrivatePort, p.Type))
+		}
+	}
+	if len(parts) == 0 {
+		return "-"
+	}
+	return strings.Join(parts, ", ")
+}

--- a/internal/runtime/factory.go
+++ b/internal/runtime/factory.go
@@ -11,7 +11,7 @@ import (
 func NewProvider(name string) (Provider, error) {
 	switch name {
 	case "", "docker":
-		cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+		cli, err := client.New(client.FromEnv)
 		if err != nil {
 			return nil, fmt.Errorf("connecting to Docker: %w", err)
 		}

--- a/internal/runtime/factory.go
+++ b/internal/runtime/factory.go
@@ -1,0 +1,22 @@
+package runtime
+
+import (
+	"fmt"
+
+	"github.com/moby/moby/client"
+)
+
+// NewProvider creates a Provider for the named container runtime.
+// An empty name defaults to "docker".
+func NewProvider(name string) (Provider, error) {
+	switch name {
+	case "", "docker":
+		cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+		if err != nil {
+			return nil, fmt.Errorf("connecting to Docker: %w", err)
+		}
+		return &DockerProvider{docker: cli}, nil
+	default:
+		return nil, fmt.Errorf("unknown provider %q (supported: docker)", name)
+	}
+}

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -2,212 +2,35 @@ package runtime
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"io"
-	"net/netip"
-	"os"
-	"strconv"
-	"strings"
-	"time"
-
-	"github.com/moby/moby/api/types/container"
-	"github.com/moby/moby/api/types/network"
-	"github.com/moby/moby/client"
-
-	"github.com/desktopus-org/desktopus/internal/progress"
 )
 
-// Manager handles container lifecycle via the Docker SDK
+// Manager is a thin facade over a Provider.
+// It exists as an extension point for future cross-cutting concerns
+// (logging, metrics) and to preserve existing call sites.
 type Manager struct {
-	docker *client.Client
+	provider Provider
 }
 
-// NewManager creates a new runtime manager
-func NewManager(docker *client.Client) *Manager {
-	return &Manager{docker: docker}
+// NewManager creates a new runtime manager backed by the given provider.
+func NewManager(provider Provider) *Manager {
+	return &Manager{provider: provider}
 }
 
-// Run creates and starts a container from a desktop config.
-// output receives pull progress if the image is not present locally.
 func (m *Manager) Run(ctx context.Context, cfg *DesktopRunConfig, opts RunOptions, output io.Writer) (string, error) {
-	if err := m.pullIfMissing(ctx, cfg.ImageTag, output); err != nil {
-		return "", err
-	}
-
-	containerName := cfg.Name
-	if opts.Name != "" {
-		containerName = opts.Name
-	}
-
-	envList := buildEnvList(cfg, opts)
-	portBindings, exposedPorts, err := buildPortBindings(cfg, opts)
-	if err != nil {
-		return "", fmt.Errorf("configuring ports: %w", err)
-	}
-	binds := buildVolumes(cfg, opts)
-
-	shmSize := parseSize(cfg.ShmSize)
-	if opts.ShmSize != "" {
-		shmSize = parseSize(opts.ShmSize)
-	}
-
-	containerCfg := &container.Config{
-		Image:        cfg.ImageTag,
-		Hostname:     cfg.Hostname,
-		Env:          envList,
-		ExposedPorts: exposedPorts,
-		Labels: map[string]string{
-			LabelManagedBy: "desktopus",
-			LabelDesktop:   cfg.Name,
-		},
-	}
-
-	hostCfg := &container.HostConfig{
-		PortBindings: portBindings,
-		Binds:        binds,
-		ShmSize:      shmSize,
-		AutoRemove:   opts.Remove,
-	}
-
-	if cfg.Restart != "" && cfg.Restart != "no" {
-		hostCfg.RestartPolicy = container.RestartPolicy{Name: container.RestartPolicyMode(cfg.Restart)}
-	}
-
-	if cfg.Memory != "" {
-		if mem := parseSize(cfg.Memory); mem > 0 {
-			hostCfg.Memory = mem
-		}
-	}
-	if cfg.CPUs > 0 {
-		hostCfg.NanoCPUs = int64(cfg.CPUs) * 1e9
-	}
-
-	if cfg.GPU || opts.GPU {
-		hostCfg.Devices = append(hostCfg.Devices, container.DeviceMapping{
-			PathOnHost:        "/dev/dri",
-			PathInContainer:   "/dev/dri",
-			CgroupPermissions: "rwm",
-		})
-	}
-
-	if cfg.Network != "" {
-		hostCfg.NetworkMode = container.NetworkMode(cfg.Network)
-	}
-
-	resp, err := m.docker.ContainerCreate(ctx, client.ContainerCreateOptions{
-		Config:     containerCfg,
-		HostConfig: hostCfg,
-		Name:       containerName,
-	})
-	if err != nil {
-		return "", fmt.Errorf("creating container: %w", err)
-	}
-
-	if _, err := m.docker.ContainerStart(ctx, resp.ID, client.ContainerStartOptions{}); err != nil {
-		return "", fmt.Errorf("starting container: %w", err)
-	}
-
-	return resp.ID, nil
+	return m.provider.Run(ctx, cfg, opts, output)
 }
 
-// pullIfMissing pulls the image if it is not already present locally.
-func (m *Manager) pullIfMissing(ctx context.Context, image string, output io.Writer) error {
-	_, err := m.docker.ImageInspect(ctx, image)
-	if err == nil {
-		return nil
-	}
-
-	fmt.Fprintf(output, "Pulling %s...\n", image)
-	rc, err := m.docker.ImagePull(ctx, image, client.ImagePullOptions{})
-	if err != nil {
-		return fmt.Errorf("pulling image %s: %w", image, err)
-	}
-	defer func() { _ = rc.Close() }()
-
-	return streamPullOutput(rc, output)
-}
-
-func streamPullOutput(reader io.Reader, output io.Writer) error {
-	decoder := json.NewDecoder(reader)
-	pr := progress.New(output)
-	for {
-		var event struct {
-			Status   string `json:"status"`
-			Progress string `json:"progress"`
-			ID       string `json:"id"`
-			Error    string `json:"error"`
-		}
-		if err := decoder.Decode(&event); err != nil {
-			if err == io.EOF {
-				pr.Flush()
-				return nil
-			}
-			return err
-		}
-		if event.Error != "" {
-			pr.Clear()
-			return fmt.Errorf("%s", event.Error)
-		}
-		if event.Status == "" {
-			continue
-		}
-		if event.ID != "" {
-			pr.Update(event.ID, event.Status, event.Progress)
-		} else {
-			pr.Print(event.Status)
-		}
-	}
-}
-
-// Stop stops a container by name or ID
 func (m *Manager) Stop(ctx context.Context, nameOrID string, timeout int) error {
-	t := timeout
-	_, err := m.docker.ContainerStop(ctx, nameOrID, client.ContainerStopOptions{Timeout: &t})
-	return err
+	return m.provider.Stop(ctx, nameOrID, timeout)
 }
 
-// Remove removes a container
 func (m *Manager) Remove(ctx context.Context, nameOrID string, force bool) error {
-	_, err := m.docker.ContainerRemove(ctx, nameOrID, client.ContainerRemoveOptions{Force: force})
-	return err
+	return m.provider.Remove(ctx, nameOrID, force)
 }
 
-// List returns all desktopus-managed containers
 func (m *Manager) List(ctx context.Context, all bool) ([]ContainerInfo, error) {
-	f := make(client.Filters)
-	f.Add("label", LabelManagedBy+"=desktopus")
-
-	result, err := m.docker.ContainerList(ctx, client.ContainerListOptions{
-		All:     all,
-		Filters: f,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("listing containers: %w", err)
-	}
-
-	infos := make([]ContainerInfo, len(result.Items))
-	for i, c := range result.Items {
-		name := ""
-		if len(c.Names) > 0 {
-			name = strings.TrimPrefix(c.Names[0], "/")
-		}
-
-		ports := formatPorts(c.Ports)
-
-		infos[i] = ContainerInfo{
-			ID:      c.ID[:12],
-			Name:    name,
-			Desktop: c.Labels[LabelDesktop],
-			Image:   c.Image,
-			Status:  string(c.State),
-			State:   c.Status,
-			Ports:   ports,
-			Created: time.Unix(c.Created, 0),
-		}
-	}
-
-	return infos, nil
+	return m.provider.List(ctx, all)
 }
 
 // DesktopRunConfig is a flattened view of what the runtime needs to create a container.
@@ -227,100 +50,4 @@ type DesktopRunConfig struct {
 
 	// Env is the merged set of all env vars (defaults + runtime.env)
 	Env map[string]string
-}
-
-func buildEnvList(cfg *DesktopRunConfig, opts RunOptions) []string {
-	env := make(map[string]string)
-	for k, v := range cfg.Env {
-		env[k] = v
-	}
-	for k, v := range opts.Env {
-		env[k] = v
-	}
-
-	list := make([]string, 0, len(env))
-	for k, v := range env {
-		list = append(list, k+"="+v)
-	}
-	return list
-}
-
-func buildPortBindings(cfg *DesktopRunConfig, opts RunOptions) (network.PortMap, network.PortSet, error) {
-	portMap := network.PortMap{}
-	portSet := network.PortSet{}
-
-	allPorts := append(cfg.Ports, opts.Ports...)
-	for _, p := range allPorts {
-		parts := strings.SplitN(p, ":", 2)
-		if len(parts) != 2 {
-			return nil, nil, fmt.Errorf("invalid port mapping %q (expected host:container)", p)
-		}
-
-		containerPort, err := network.ParsePort(parts[1] + "/tcp")
-		if err != nil {
-			return nil, nil, fmt.Errorf("invalid container port %q: %w", parts[1], err)
-		}
-		portSet[containerPort] = struct{}{}
-		portMap[containerPort] = []network.PortBinding{
-			{HostIP: netip.MustParseAddr("0.0.0.0"), HostPort: parts[0]},
-		}
-	}
-
-	return portMap, portSet, nil
-}
-
-func buildVolumes(cfg *DesktopRunConfig, opts RunOptions) []string {
-	allVolumes := append(cfg.Volumes, opts.Volumes...)
-
-	binds := make([]string, 0, len(allVolumes))
-	for _, v := range allVolumes {
-		if strings.HasPrefix(v, "~/") {
-			if home, err := os.UserHomeDir(); err == nil {
-				v = home + v[1:]
-			}
-		}
-		binds = append(binds, v)
-	}
-	return binds
-}
-
-func parseSize(s string) int64 {
-	if s == "" {
-		return 0
-	}
-	s = strings.TrimSpace(strings.ToLower(s))
-	multiplier := int64(1)
-
-	if strings.HasSuffix(s, "g") {
-		multiplier = 1024 * 1024 * 1024
-		s = strings.TrimSuffix(s, "g")
-	} else if strings.HasSuffix(s, "m") {
-		multiplier = 1024 * 1024
-		s = strings.TrimSuffix(s, "m")
-	} else if strings.HasSuffix(s, "k") {
-		multiplier = 1024
-		s = strings.TrimSuffix(s, "k")
-	}
-
-	n, err := strconv.ParseInt(s, 10, 64)
-	if err != nil {
-		return 0
-	}
-	return n * multiplier
-}
-
-func formatPorts(ports []container.PortSummary) string {
-	if len(ports) == 0 {
-		return "-"
-	}
-	parts := make([]string, 0, len(ports))
-	for _, p := range ports {
-		if p.PublicPort > 0 {
-			parts = append(parts, fmt.Sprintf("%s:%d->%d/%s", p.IP.String(), p.PublicPort, p.PrivatePort, p.Type))
-		}
-	}
-	if len(parts) == 0 {
-		return "-"
-	}
-	return strings.Join(parts, ", ")
 }

--- a/internal/runtime/provider.go
+++ b/internal/runtime/provider.go
@@ -1,0 +1,15 @@
+package runtime
+
+import (
+	"context"
+	"io"
+)
+
+// Provider abstracts a container runtime backend.
+type Provider interface {
+	Run(ctx context.Context, cfg *DesktopRunConfig, opts RunOptions, output io.Writer) (string, error)
+	Stop(ctx context.Context, nameOrID string, timeout int) error
+	Remove(ctx context.Context, nameOrID string, force bool) error
+	List(ctx context.Context, all bool) ([]ContainerInfo, error)
+	Close() error
+}

--- a/internal/runtime/provider_test.go
+++ b/internal/runtime/provider_test.go
@@ -1,0 +1,113 @@
+package runtime
+
+import (
+	"context"
+	"io"
+	"testing"
+)
+
+// compile-time check: mockProvider satisfies Provider
+var _ Provider = (*mockProvider)(nil)
+
+type mockProvider struct {
+	runCalled    bool
+	stopCalled   bool
+	removeCalled bool
+	listCalled   bool
+	closeCalled  bool
+
+	runResult    string
+	runErr       error
+	stopErr      error
+	removeErr    error
+	listResult   []ContainerInfo
+	listErr      error
+}
+
+func (m *mockProvider) Run(_ context.Context, _ *DesktopRunConfig, _ RunOptions, _ io.Writer) (string, error) {
+	m.runCalled = true
+	return m.runResult, m.runErr
+}
+
+func (m *mockProvider) Stop(_ context.Context, _ string, _ int) error {
+	m.stopCalled = true
+	return m.stopErr
+}
+
+func (m *mockProvider) Remove(_ context.Context, _ string, _ bool) error {
+	m.removeCalled = true
+	return m.removeErr
+}
+
+func (m *mockProvider) List(_ context.Context, _ bool) ([]ContainerInfo, error) {
+	m.listCalled = true
+	return m.listResult, m.listErr
+}
+
+func (m *mockProvider) Close() error {
+	m.closeCalled = true
+	return nil
+}
+
+func TestManagerDelegatesRun(t *testing.T) {
+	mock := &mockProvider{runResult: "abc123"}
+	mgr := NewManager(mock)
+
+	id, err := mgr.Run(context.Background(), &DesktopRunConfig{}, RunOptions{}, io.Discard)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != "abc123" {
+		t.Errorf("expected id abc123, got %q", id)
+	}
+	if !mock.runCalled {
+		t.Error("expected Run to be called on provider")
+	}
+}
+
+func TestManagerDelegatesStop(t *testing.T) {
+	mock := &mockProvider{}
+	mgr := NewManager(mock)
+
+	if err := mgr.Stop(context.Background(), "mycontainer", 10); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !mock.stopCalled {
+		t.Error("expected Stop to be called on provider")
+	}
+}
+
+func TestManagerDelegatesRemove(t *testing.T) {
+	mock := &mockProvider{}
+	mgr := NewManager(mock)
+
+	if err := mgr.Remove(context.Background(), "mycontainer", false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !mock.removeCalled {
+		t.Error("expected Remove to be called on provider")
+	}
+}
+
+func TestManagerDelegatesList(t *testing.T) {
+	mock := &mockProvider{
+		listResult: []ContainerInfo{
+			{ID: "abc123", Name: "mydesk"},
+		},
+	}
+	mgr := NewManager(mock)
+
+	containers, err := mgr.List(context.Background(), false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(containers) != 1 {
+		t.Errorf("expected 1 container, got %d", len(containers))
+	}
+	if containers[0].ID != "abc123" {
+		t.Errorf("expected ID abc123, got %q", containers[0].ID)
+	}
+	if !mock.listCalled {
+		t.Error("expected List to be called on provider")
+	}
+}


### PR DESCRIPTION
## Summary

- Introduces a `Provider` interface in `internal/runtime/` abstracting the container backend
- Moves all Docker SDK logic from `Manager` into `DockerProvider`; `Manager` becomes a thin facade
- Adds `NewProvider(name string)` factory that creates its own Docker client — CLI commands no longer import the Docker SDK for runtime operations
- Adds `provider` field to `RuntimeConfig` with validation (`docker` is the only valid value, empty defaults to docker)
- `list` and `stop` pass `""` (→ docker) since they don't load `RuntimeConfig`

## Test plan

- [x] `mage test` — all existing tests pass
- [x] `mage build` — compiles cleanly
- [x] `go test ./internal/config/ -run TestValidateRuntime -v` — provider validation tests
- [x] `go test ./internal/runtime/ -v` — Manager delegation tests via `mockProvider`