### PR TITLE
feat: GPU type support with Wayland acceleration and examples

### DIFF
--- a/examples/amd-gpu/desktopus.runtime.yaml
+++ b/examples/amd-gpu/desktopus.runtime.yaml
@@ -1,0 +1,25 @@
+name: amd-desktop
+image: amd-desktop:latest
+shm_size: 2g
+
+# AMD GPU passthrough via /dev/dri
+# Requires amdgpu kernel module loaded on the host.
+# Add the container user to the 'video' and 'render' groups on the host if needed.
+gpu: amd
+
+ports:
+  - "3000:3000"   # web UI (HTTP)
+  - "3001:3001"   # web UI (HTTPS)
+
+env:
+  PUID: "1000"
+  PGID: "1000"
+  TZ: UTC
+  # Desktopus automatically sets:
+  #   PIXELFLUX_WAYLAND=true   (Wayland compositor with zero-copy encoding)
+  #   DRINODE=/dev/dri/renderD128   (render node for EGL/3D)
+  #   DRI_NODE=/dev/dri/renderD128  (render node for VAAPI encoding)
+  #
+  # Override DRINODE/DRI_NODE if you have multiple GPUs and want a specific one:
+  # DRINODE: /dev/dri/renderD129
+  # DRI_NODE: /dev/dri/renderD129

--- a/examples/amd-gpu/desktopus.yaml
+++ b/examples/amd-gpu/desktopus.yaml
@@ -1,0 +1,10 @@
+name: amd-desktop
+description: "Ubuntu/XFCE desktop with AMD GPU passthrough for hardware-accelerated video"
+image: amd-desktop:latest
+
+base:
+  os: ubuntu
+  desktop: xfce
+
+modules:
+  - chrome

--- a/examples/basic/desktopus.runtime.yaml
+++ b/examples/basic/desktopus.runtime.yaml
@@ -1,0 +1,12 @@
+name: basic-desktop
+image: basic-desktop:latest
+shm_size: 1g
+
+ports:
+  - "3000:3000"   # web UI (HTTP)
+  - "3001:3001"   # web UI (HTTPS)
+
+env:
+  PUID: "1000"
+  PGID: "1000"
+  TZ: UTC

--- a/examples/basic/desktopus.yaml
+++ b/examples/basic/desktopus.yaml
@@ -1,0 +1,10 @@
+name: basic-desktop
+description: "Minimal Ubuntu/XFCE desktop with no GPU passthrough"
+image: basic-desktop:latest
+
+base:
+  os: ubuntu
+  desktop: xfce
+
+modules:
+  - chrome

--- a/examples/intel-gpu/desktopus.runtime.yaml
+++ b/examples/intel-gpu/desktopus.runtime.yaml
@@ -1,0 +1,24 @@
+name: intel-desktop
+image: intel-desktop:latest
+shm_size: 2g
+
+# Intel GPU passthrough via /dev/dri
+# Requires i915 kernel module loaded on the host.
+gpu: intel
+
+ports:
+  - "3000:3000"   # web UI (HTTP)
+  - "3001:3001"   # web UI (HTTPS)
+
+env:
+  PUID: "1000"
+  PGID: "1000"
+  TZ: UTC
+  # Desktopus automatically sets:
+  #   PIXELFLUX_WAYLAND=true   (Wayland compositor with zero-copy encoding)
+  #   DRINODE=/dev/dri/renderD128   (render node for EGL/3D)
+  #   DRI_NODE=/dev/dri/renderD128  (render node for VAAPI encoding)
+  #
+  # Override DRINODE/DRI_NODE if you have multiple GPUs and want a specific one:
+  # DRINODE: /dev/dri/renderD129
+  # DRI_NODE: /dev/dri/renderD129

--- a/examples/intel-gpu/desktopus.yaml
+++ b/examples/intel-gpu/desktopus.yaml
@@ -1,0 +1,10 @@
+name: intel-desktop
+description: "Ubuntu/XFCE desktop with Intel GPU passthrough for hardware-accelerated video"
+image: intel-desktop:latest
+
+base:
+  os: ubuntu
+  desktop: xfce
+
+modules:
+  - chrome

--- a/examples/nvidia-gpu/desktopus.runtime.yaml
+++ b/examples/nvidia-gpu/desktopus.runtime.yaml
@@ -1,0 +1,29 @@
+name: nvidia-desktop
+image: nvidia-desktop:latest
+shm_size: 2g
+
+# Nvidia GPU passthrough via nvidia-container-toolkit.
+#
+# Requirements:
+#   1. Nvidia driver >= 580 on the host
+#   2. Kernel parameter: nvidia-drm.modeset=1 (add to bootloader config)
+#   3. On headless systems, run once per boot: nvidia-modprobe --modeset
+#   4. Configure Docker for Nvidia runtime:
+#        sudo nvidia-ctk runtime configure --runtime=docker
+#        sudo systemctl restart docker
+#
+# Note: Nvidia is not supported on alpine-based images.
+gpu: nvidia
+
+ports:
+  - "3000:3000"   # web UI (HTTP)
+  - "3001:3001"   # web UI (HTTPS)
+
+env:
+  PUID: "1000"
+  PGID: "1000"
+  TZ: UTC
+  # Desktopus automatically sets:
+  #   PIXELFLUX_WAYLAND=true   (Wayland compositor with zero-copy encoding)
+  #   DRINODE=/dev/dri/renderD128   (render node for EGL/3D — auto-injected by nvidia runtime)
+  #   DRI_NODE=/dev/dri/renderD128  (render node for NVENC encoding)

--- a/examples/nvidia-gpu/desktopus.yaml
+++ b/examples/nvidia-gpu/desktopus.yaml
@@ -1,0 +1,10 @@
+name: nvidia-desktop
+description: "Ubuntu/KDE desktop with Nvidia GPU passthrough"
+image: nvidia-desktop:latest
+
+base:
+  os: ubuntu
+  desktop: kde
+
+modules:
+  - chrome

--- a/internal/build/templates/Dockerfile.tmpl
+++ b/internal/build/templates/Dockerfile.tmpl
@@ -152,3 +152,4 @@ RUN chmod +x /custom-cont-init.d/99-desktopus-files.sh
 # ============================================
 LABEL org.desktopus.name="{{ .Name }}"
 LABEL org.desktopus.description="{{ .Description }}"
+LABEL org.desktopus.base-os="{{ .OS }}"

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -16,7 +16,7 @@ import (
 var (
 	runFile    string
 	runDetach  bool
-	runGPU     bool
+	runGPUType string
 	runPorts   []string
 	runVolumes []string
 	runEnvs    []string
@@ -71,7 +71,7 @@ var runCmd = &cobra.Command{
 		opts := runtime.RunOptions{
 			Name:    runName,
 			Detach:  runDetach,
-			GPU:     runGPU,
+			GPUType: runGPUType,
 			Ports:   runPorts,
 			Volumes: runVolumes,
 			Env:     envMap,
@@ -100,7 +100,7 @@ var runCmd = &cobra.Command{
 func init() {
 	runCmd.Flags().StringVarP(&runFile, "file", "f", "", "path to desktopus.runtime.yaml or its directory")
 	runCmd.Flags().BoolVarP(&runDetach, "detach", "d", true, "run in background")
-	runCmd.Flags().BoolVar(&runGPU, "gpu", false, "enable GPU passthrough")
+	runCmd.Flags().StringVar(&runGPUType, "gpu", "", "GPU type for passthrough (intel|amd|nvidia)")
 	runCmd.Flags().StringArrayVar(&runPorts, "port", nil, "additional port mappings (host:container)")
 	runCmd.Flags().StringArrayVar(&runVolumes, "volume", nil, "additional volume mounts")
 	runCmd.Flags().StringArrayVar(&runEnvs, "env", nil, "set environment variables (KEY=VALUE)")

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -115,7 +115,7 @@ func TestToDesktopRunConfigMapsRuntimeFields(t *testing.T) {
 		ShmSize:  "4g",
 		Ports:    []string{"3000:3000"},
 		Volumes:  []string{"~/projects:/config/projects"},
-		GPU:      true,
+		GPU:      "intel",
 		Memory:   "8g",
 		CPUs:     4,
 		Restart:  "unless-stopped",
@@ -131,7 +131,7 @@ func TestToDesktopRunConfigMapsRuntimeFields(t *testing.T) {
 	}{
 		{"Hostname", cfg.Hostname, "myhost"},
 		{"ShmSize", cfg.ShmSize, "4g"},
-		{"GPU", cfg.GPU, true},
+		{"GPU", cfg.GPU, "intel"},
 		{"Memory", cfg.Memory, "8g"},
 		{"CPUs", cfg.CPUs, 4},
 		{"Restart", cfg.Restart, "unless-stopped"},

--- a/internal/config/desktop.go
+++ b/internal/config/desktop.go
@@ -121,7 +121,7 @@ type RuntimeConfig struct {
 	ShmSize  string            `yaml:"shm_size,omitempty"`
 	Ports    []string          `yaml:"ports,omitempty"`   // "host:container"
 	Volumes  []string          `yaml:"volumes,omitempty"` // "host:container[:ro]"
-	GPU      bool              `yaml:"gpu,omitempty"`
+	GPU      string            `yaml:"gpu,omitempty"` // intel | amd | nvidia
 	Memory   string            `yaml:"memory,omitempty"`
 	CPUs     int               `yaml:"cpus,omitempty"`
 	Restart  string            `yaml:"restart,omitempty"` // no | always | unless-stopped

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -119,6 +119,7 @@ func ValidateImage(cfg *ImageConfig) error {
 
 var validRestartPolicies = []string{"no", "always", "unless-stopped", "on-failure"}
 var validProviders = []string{"docker"}
+var validGPUTypes = []string{"intel", "amd", "nvidia"}
 
 // ValidateRuntime checks a RuntimeConfig for errors
 func ValidateRuntime(cfg *RuntimeConfig) error {
@@ -132,6 +133,11 @@ func ValidateRuntime(cfg *RuntimeConfig) error {
 	if cfg.Provider != "" && !sliceContains(validProviders, cfg.Provider) {
 		errs = append(errs, fmt.Sprintf("provider %q is not supported (valid: %s)",
 			cfg.Provider, strings.Join(validProviders, ", ")))
+	}
+
+	if cfg.GPU != "" && !sliceContains(validGPUTypes, cfg.GPU) {
+		errs = append(errs, fmt.Sprintf("gpu %q is not supported (valid: %s)",
+			cfg.GPU, strings.Join(validGPUTypes, ", ")))
 	}
 
 	if len(errs) > 0 {

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -35,12 +35,37 @@ func (d *DockerProvider) Run(ctx context.Context, cfg *DesktopRunConfig, opts Ru
 		return "", err
 	}
 
+	gpuType := cfg.GPU
+	if opts.GPUType != "" {
+		gpuType = opts.GPUType
+	}
+
+	if err := d.checkGPUCompatibility(ctx, cfg.ImageTag, gpuType); err != nil {
+		return "", err
+	}
+
 	containerName := cfg.Name
 	if opts.Name != "" {
 		containerName = opts.Name
 	}
 
-	envList := buildEnvList(cfg, opts)
+	envMap := buildEnvMap(cfg, opts)
+	if gpuType != "" {
+		// Enable Wayland compositor with zero-copy GPU encoding.
+		// DRINODE/DRI_NODE select the render device for EGL and VAAPI/NVENC.
+		// Users can override these via env: in desktopus.runtime.yaml.
+		if _, ok := envMap["PIXELFLUX_WAYLAND"]; !ok {
+			envMap["PIXELFLUX_WAYLAND"] = "true"
+		}
+		if _, ok := envMap["DRINODE"]; !ok {
+			envMap["DRINODE"] = "/dev/dri/renderD128"
+		}
+		if _, ok := envMap["DRI_NODE"]; !ok {
+			envMap["DRI_NODE"] = "/dev/dri/renderD128"
+		}
+	}
+	envList := envMapToList(envMap)
+
 	portBindings, exposedPorts, err := buildPortBindings(cfg, opts)
 	if err != nil {
 		return "", fmt.Errorf("configuring ports: %w", err)
@@ -83,11 +108,18 @@ func (d *DockerProvider) Run(ctx context.Context, cfg *DesktopRunConfig, opts Ru
 		hostCfg.NanoCPUs = int64(cfg.CPUs) * 1e9
 	}
 
-	if cfg.GPU || opts.GPU {
+	switch gpuType {
+	case "intel", "amd":
 		hostCfg.Devices = append(hostCfg.Devices, container.DeviceMapping{
 			PathOnHost:        "/dev/dri",
 			PathInContainer:   "/dev/dri",
 			CgroupPermissions: "rwm",
+		})
+	case "nvidia":
+		hostCfg.DeviceRequests = append(hostCfg.DeviceRequests, container.DeviceRequest{
+			Driver:       "nvidia",
+			Count:        -1,
+			Capabilities: [][]string{{"compute", "video", "graphics", "utility"}},
 		})
 	}
 
@@ -161,6 +193,23 @@ func (d *DockerProvider) List(ctx context.Context, all bool) ([]ContainerInfo, e
 	return infos, nil
 }
 
+// checkGPUCompatibility inspects the image's desktopus labels and rejects
+// combinations that are known to be unsupported (e.g. nvidia on alpine).
+// If the image has no desktopus labels (non-desktopus image), the check is skipped.
+func (d *DockerProvider) checkGPUCompatibility(ctx context.Context, image, gpuType string) error {
+	if gpuType != "nvidia" {
+		return nil
+	}
+	info, err := d.docker.ImageInspect(ctx, image)
+	if err != nil || info.Config == nil {
+		return nil // image not inspectable or no config — skip
+	}
+	if baseOS := info.Config.Labels[LabelBaseOS]; baseOS == "alpine" {
+		return fmt.Errorf("gpu \"nvidia\" is not supported on alpine: musl libc is incompatible with Nvidia proprietary drivers; use ubuntu, debian, fedora, arch, or el as the base OS")
+	}
+	return nil
+}
+
 // pullIfMissing pulls the image if it is not already present locally.
 func (d *DockerProvider) pullIfMissing(ctx context.Context, image string, output io.Writer) error {
 	_, err := d.docker.ImageInspect(ctx, image)
@@ -210,7 +259,7 @@ func streamPullOutput(reader io.Reader, output io.Writer) error {
 	}
 }
 
-func buildEnvList(cfg *DesktopRunConfig, opts RunOptions) []string {
+func buildEnvMap(cfg *DesktopRunConfig, opts RunOptions) map[string]string {
 	env := make(map[string]string)
 	for k, v := range cfg.Env {
 		env[k] = v
@@ -218,12 +267,19 @@ func buildEnvList(cfg *DesktopRunConfig, opts RunOptions) []string {
 	for k, v := range opts.Env {
 		env[k] = v
 	}
+	return env
+}
 
+func envMapToList(env map[string]string) []string {
 	list := make([]string, 0, len(env))
 	for k, v := range env {
 		list = append(list, k+"="+v)
 	}
 	return list
+}
+
+func buildEnvList(cfg *DesktopRunConfig, opts RunOptions) []string {
+	return envMapToList(buildEnvMap(cfg, opts))
 }
 
 func buildPortBindings(cfg *DesktopRunConfig, opts RunOptions) (network.PortMap, network.PortSet, error) {

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -42,7 +42,7 @@ type DesktopRunConfig struct {
 	ShmSize  string
 	Ports    []string
 	Volumes  []string
-	GPU      bool
+	GPU      string // intel | amd | nvidia
 	Memory   string
 	CPUs     int
 	Restart  string

--- a/internal/runtime/options.go
+++ b/internal/runtime/options.go
@@ -6,7 +6,7 @@ import "time"
 type RunOptions struct {
 	Name    string            // Override container name
 	Detach  bool              // Run in background
-	GPU     bool              // Force GPU enable
+	GPUType string            // GPU type override (intel|amd|nvidia)
 	Ports   []string          // Additional port mappings (host:container)
 	Volumes []string          // Additional volume mounts (host:container[:ro])
 	Env     map[string]string // Additional env vars
@@ -30,4 +30,5 @@ type ContainerInfo struct {
 const (
 	LabelManagedBy = "org.desktopus.managed-by"
 	LabelDesktop   = "org.desktopus.desktop"
+	LabelBaseOS    = "org.desktopus.base-os"
 )


### PR DESCRIPTION
## Summary

- Replaces the boolean `gpu` flag with a typed string field (`intel|amd|nvidia`) in `RuntimeConfig`, `DesktopRunConfig`, and `RunOptions`
- Each GPU type maps to the correct Docker configuration for linuxserver/webtop Wayland GPU acceleration:
  - **Intel/AMD**: `/dev/dri` device passthrough
  - **Nvidia**: `DeviceRequest` with `compute/video/graphics/utility` capabilities
- Auto-injects `PIXELFLUX_WAYLAND=true`, `DRINODE`, and `DRI_NODE` for all GPU types to enable zero-copy Wayland encoding (users can override via `env:`)
- Adds `org.desktopus.base-os` Docker image label at build time and a runtime check that rejects `gpu: nvidia` on alpine images (musl libc incompatibility)
- Adds `examples/` with four scenarios: `basic`, `intel-gpu`, `amd-gpu`, `nvidia-gpu`