### PR TITLE
feat: persistence support and volume management

### DIFF
--- a/internal/build/templates/Dockerfile.tmpl
+++ b/internal/build/templates/Dockerfile.tmpl
@@ -153,3 +153,4 @@ RUN chmod +x /custom-cont-init.d/99-desktopus-files.sh
 LABEL org.desktopus.name="{{ .Name }}"
 LABEL org.desktopus.description="{{ .Description }}"
 LABEL org.desktopus.base-os="{{ .OS }}"
+LABEL org.desktopus.user="{{ .User }}"

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -93,6 +93,7 @@ modules:
 func generateRuntimeYAML(name string) string {
 	return fmt.Sprintf(`name: %s
 shm_size: 2g
+image: %s:latest
 ports:
   - "3000:3000"
   - "3001:3001"
@@ -103,5 +104,5 @@ env:
   PUID: "1000"
   PGID: "1000"
   TZ: UTC
-`, name)
+`, name, name)
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -47,6 +47,7 @@ func init() {
 	rootCmd.AddCommand(runCmd)
 	rootCmd.AddCommand(stopCmd)
 	rootCmd.AddCommand(listCmd)
+	rootCmd.AddCommand(volumeCmd)
 }
 
 // Execute runs the root command

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -174,8 +174,9 @@ func toDesktopRunConfig(rt *config.RuntimeConfig, imageTag string) *runtime.Desk
 		GPU:      rt.GPU,
 		Memory:   rt.Memory,
 		CPUs:     rt.CPUs,
-		Restart:  rt.Restart,
-		Network:  rt.Network,
-		Env:      env,
+		Restart:         rt.Restart,
+		Network:         rt.Network,
+		Env:             env,
+		PersistenceHome: rt.PersistenceHome,
 	}
 }

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -150,5 +150,19 @@ func TestToDesktopRunConfigMapsRuntimeFields(t *testing.T) {
 	}
 }
 
+func TestToDesktopRunConfigPersistenceHome(t *testing.T) {
+	rt := &config.RuntimeConfig{PersistenceHome: "my-desktop-data"}
+	cfg := toDesktopRunConfig(rt, "mydesk:latest")
+	if cfg.PersistenceHome != "my-desktop-data" {
+		t.Errorf("expected PersistenceHome 'my-desktop-data', got %q", cfg.PersistenceHome)
+	}
+
+	rt2 := &config.RuntimeConfig{}
+	cfg2 := toDesktopRunConfig(rt2, "mydesk:latest")
+	if cfg2.PersistenceHome != "" {
+		t.Errorf("expected PersistenceHome empty, got %q", cfg2.PersistenceHome)
+	}
+}
+
 // verify toDesktopRunConfig returns the right type
 var _ *runtime.DesktopRunConfig = (*runtime.DesktopRunConfig)(nil)

--- a/internal/cli/volume.go
+++ b/internal/cli/volume.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/desktopus-org/desktopus/internal/runtime"
+)
+
+var volumeForce bool
+
+var volumeCmd = &cobra.Command{
+	Use:   "volume",
+	Short: "Manage desktopus volumes",
+}
+
+var volumeLsCmd = &cobra.Command{
+	Use:   "ls",
+	Short: "List desktopus-managed volumes",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		provider, err := runtime.NewProvider("")
+		if err != nil {
+			return err
+		}
+		defer func() { _ = provider.Close() }()
+
+		mgr := runtime.NewManager(provider)
+		volumes, err := mgr.VolumeList(context.Background())
+		if err != nil {
+			return err
+		}
+
+		if len(volumes) == 0 {
+			fmt.Println("No desktopus volumes found.")
+			return nil
+		}
+
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "NAME\tDESKTOP\tTYPE")
+		for _, v := range volumes {
+			t := v.Type
+			if t == "" {
+				t = "-"
+			}
+			fmt.Fprintf(w, "%s\t%s\t%s\n", v.Name, v.Desktop, t)
+		}
+		return w.Flush()
+	},
+}
+
+var volumeRmCmd = &cobra.Command{
+	Use:   "rm <name...>",
+	Short: "Remove desktopus-managed volume(s)",
+	Args:  cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		provider, err := runtime.NewProvider("")
+		if err != nil {
+			return err
+		}
+		defer func() { _ = provider.Close() }()
+
+		mgr := runtime.NewManager(provider)
+		ctx := context.Background()
+
+		for _, name := range args {
+			if err := mgr.VolumeRemove(ctx, name, volumeForce); err != nil {
+				fmt.Printf("Warning: failed to remove %s: %v\n", name, err)
+			} else {
+				fmt.Printf("Removed volume %s\n", name)
+			}
+		}
+		return nil
+	},
+}
+
+func init() {
+	volumeRmCmd.Flags().BoolVar(&volumeForce, "force", false, "force removal even if volume is in use")
+	volumeCmd.AddCommand(volumeLsCmd)
+	volumeCmd.AddCommand(volumeRmCmd)
+}

--- a/internal/config/desktop.go
+++ b/internal/config/desktop.go
@@ -127,7 +127,8 @@ type RuntimeConfig struct {
 	Restart  string            `yaml:"restart,omitempty"` // no | always | unless-stopped
 	Network  string            `yaml:"network,omitempty"`
 	Env      map[string]string `yaml:"env,omitempty"`
-	Provider string            `yaml:"provider,omitempty"` // container runtime provider (default: docker)
+	Provider        string            `yaml:"provider,omitempty"`         // container runtime provider (default: docker)
+	PersistenceHome string            `yaml:"persistence_home,omitempty"` // named Docker volume to mount at home/config
 }
 
 // ResolveImageTag resolves the Docker image tag in priority order:

--- a/internal/runtime/docker.go
+++ b/internal/runtime/docker.go
@@ -71,6 +71,10 @@ func (d *DockerProvider) Run(ctx context.Context, cfg *DesktopRunConfig, opts Ru
 		return "", fmt.Errorf("configuring ports: %w", err)
 	}
 	binds := buildVolumes(cfg, opts)
+	if cfg.PersistenceHome != "" {
+		binds = append(binds, d.persistenceBind(ctx, cfg))
+	}
+	d.ensureNamedVolumes(ctx, binds, cfg)
 
 	shmSize := parseSize(cfg.ShmSize)
 	if opts.ShmSize != "" {
@@ -344,6 +348,79 @@ func parseSize(s string) int64 {
 		return 0
 	}
 	return n * multiplier
+}
+
+// persistenceBind returns a named-volume bind string for the desktop's persistent
+// data directory. It inspects the image for org.desktopus.user to determine the
+// correct mount path: /config for the abc user, /home/<user> otherwise.
+// The volume is named <container-name>-data and is auto-created by Docker if absent.
+func (d *DockerProvider) persistenceBind(ctx context.Context, cfg *DesktopRunConfig) string {
+	var userLabel string
+	info, err := d.docker.ImageInspect(ctx, cfg.ImageTag)
+	if err == nil && info.Config != nil {
+		userLabel = info.Config.Labels[LabelUser]
+	}
+	return cfg.PersistenceHome + ":" + persistenceMountPath(userLabel)
+}
+
+// persistenceMountPath returns the container path to mount for persistence.
+// /config is used for the abc user (linuxserver/webtop default), /home/<user> otherwise.
+func persistenceMountPath(userLabel string) string {
+	if userLabel == "" || userLabel == "abc" {
+		return "/config"
+	}
+	return "/home/" + userLabel
+}
+
+// ensureNamedVolumes creates any named Docker volumes in binds that don't yet
+// exist, labelling them so desktopus can track them. Bind mounts (sources
+// starting with "/") are skipped. Errors are silently ignored — Docker will
+// handle missing volumes at container creation time.
+func (d *DockerProvider) ensureNamedVolumes(ctx context.Context, binds []string, cfg *DesktopRunConfig) {
+	for _, bind := range binds {
+		source := strings.SplitN(bind, ":", 2)[0]
+		if strings.HasPrefix(source, "/") {
+			continue // bind mount
+		}
+		labels := map[string]string{
+			LabelManagedBy: "desktopus",
+			LabelDesktop:   cfg.Name,
+		}
+		if source == cfg.PersistenceHome {
+			labels[LabelVolumeType] = "home"
+		}
+		_, _ = d.docker.VolumeCreate(ctx, client.VolumeCreateOptions{
+			Name:   source,
+			Labels: labels,
+		})
+	}
+}
+
+// VolumeList returns all desktopus-managed Docker volumes.
+func (d *DockerProvider) VolumeList(ctx context.Context) ([]VolumeInfo, error) {
+	f := make(client.Filters)
+	f.Add("label", LabelManagedBy+"=desktopus")
+
+	result, err := d.docker.VolumeList(ctx, client.VolumeListOptions{Filters: f})
+	if err != nil {
+		return nil, fmt.Errorf("listing volumes: %w", err)
+	}
+
+	infos := make([]VolumeInfo, len(result.Items))
+	for i, v := range result.Items {
+		infos[i] = VolumeInfo{
+			Name:    v.Name,
+			Desktop: v.Labels[LabelDesktop],
+			Type:    v.Labels[LabelVolumeType],
+		}
+	}
+	return infos, nil
+}
+
+// VolumeRemove removes a desktopus-managed Docker volume by name.
+func (d *DockerProvider) VolumeRemove(ctx context.Context, name string, force bool) error {
+	_, err := d.docker.VolumeRemove(ctx, name, client.VolumeRemoveOptions{Force: force})
+	return err
 }
 
 func formatPorts(ports []container.PortSummary) string {

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -33,6 +33,14 @@ func (m *Manager) List(ctx context.Context, all bool) ([]ContainerInfo, error) {
 	return m.provider.List(ctx, all)
 }
 
+func (m *Manager) VolumeList(ctx context.Context) ([]VolumeInfo, error) {
+	return m.provider.VolumeList(ctx)
+}
+
+func (m *Manager) VolumeRemove(ctx context.Context, name string, force bool) error {
+	return m.provider.VolumeRemove(ctx, name, force)
+}
+
 // DesktopRunConfig is a flattened view of what the runtime needs to create a container.
 // This decouples the runtime package from the config package.
 type DesktopRunConfig struct {
@@ -50,4 +58,8 @@ type DesktopRunConfig struct {
 
 	// Env is the merged set of all env vars (defaults + runtime.env)
 	Env map[string]string
+
+	// PersistenceHome, when non-empty, is the name of a Docker volume to mount
+	// at the user's home directory (/config for abc, /home/<user> otherwise).
+	PersistenceHome string
 }

--- a/internal/runtime/manager_test.go
+++ b/internal/runtime/manager_test.go
@@ -184,6 +184,26 @@ func TestFormatPortsEmpty(t *testing.T) {
 	}
 }
 
+func TestPersistenceMountPath(t *testing.T) {
+	tests := []struct {
+		userLabel string
+		want      string
+	}{
+		{"", "/config"},       // no label → default abc behavior
+		{"abc", "/config"},    // explicit abc user → /config
+		{"desktopus", "/home/desktopus"},
+		{"alice", "/home/alice"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.userLabel, func(t *testing.T) {
+			got := persistenceMountPath(tt.userLabel)
+			if got != tt.want {
+				t.Errorf("persistenceMountPath(%q) = %q, want %q", tt.userLabel, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFormatPortsNoPublic(t *testing.T) {
 	ports := []container.PortSummary{
 		{PrivatePort: 3000, PublicPort: 0, Type: "tcp"},

--- a/internal/runtime/options.go
+++ b/internal/runtime/options.go
@@ -26,9 +26,18 @@ type ContainerInfo struct {
 	Created time.Time
 }
 
-// Labels used to track desktopus-managed containers
+// Labels used to track desktopus-managed containers and volumes
 const (
-	LabelManagedBy = "org.desktopus.managed-by"
-	LabelDesktop   = "org.desktopus.desktop"
-	LabelBaseOS    = "org.desktopus.base-os"
+	LabelManagedBy  = "org.desktopus.managed-by"
+	LabelDesktop    = "org.desktopus.desktop"
+	LabelBaseOS     = "org.desktopus.base-os"
+	LabelUser       = "org.desktopus.user"
+	LabelVolumeType = "org.desktopus.volume-type"
 )
+
+// VolumeInfo represents a desktopus-managed Docker volume
+type VolumeInfo struct {
+	Name    string
+	Desktop string // from org.desktopus.desktop label
+	Type    string // from org.desktopus.volume-type label (e.g. "home")
+}

--- a/internal/runtime/provider.go
+++ b/internal/runtime/provider.go
@@ -11,5 +11,7 @@ type Provider interface {
 	Stop(ctx context.Context, nameOrID string, timeout int) error
 	Remove(ctx context.Context, nameOrID string, force bool) error
 	List(ctx context.Context, all bool) ([]ContainerInfo, error)
+	VolumeList(ctx context.Context) ([]VolumeInfo, error)
+	VolumeRemove(ctx context.Context, name string, force bool) error
 	Close() error
 }

--- a/internal/runtime/provider_test.go
+++ b/internal/runtime/provider_test.go
@@ -10,18 +10,23 @@ import (
 var _ Provider = (*mockProvider)(nil)
 
 type mockProvider struct {
-	runCalled    bool
-	stopCalled   bool
-	removeCalled bool
-	listCalled   bool
-	closeCalled  bool
+	runCalled         bool
+	stopCalled        bool
+	removeCalled      bool
+	listCalled        bool
+	volumeListCalled  bool
+	volumeRemoveCalled bool
+	closeCalled       bool
 
-	runResult    string
-	runErr       error
-	stopErr      error
-	removeErr    error
-	listResult   []ContainerInfo
-	listErr      error
+	runResult         string
+	runErr            error
+	stopErr           error
+	removeErr         error
+	listResult        []ContainerInfo
+	listErr           error
+	volumeListResult  []VolumeInfo
+	volumeListErr     error
+	volumeRemoveErr   error
 }
 
 func (m *mockProvider) Run(_ context.Context, _ *DesktopRunConfig, _ RunOptions, _ io.Writer) (string, error) {
@@ -42,6 +47,16 @@ func (m *mockProvider) Remove(_ context.Context, _ string, _ bool) error {
 func (m *mockProvider) List(_ context.Context, _ bool) ([]ContainerInfo, error) {
 	m.listCalled = true
 	return m.listResult, m.listErr
+}
+
+func (m *mockProvider) VolumeList(_ context.Context) ([]VolumeInfo, error) {
+	m.volumeListCalled = true
+	return m.volumeListResult, m.volumeListErr
+}
+
+func (m *mockProvider) VolumeRemove(_ context.Context, _ string, _ bool) error {
+	m.volumeRemoveCalled = true
+	return m.volumeRemoveErr
 }
 
 func (m *mockProvider) Close() error {


### PR DESCRIPTION
## Summary

- Add `persistence_home` to `desktopus.runtime.yaml` — set it to a Docker volume name to persist the user's home directory across container restarts and removals
- The volume is mounted at the right path automatically: `/config` for the `abc` user, `/home/<user>` for custom users (resolved from the `org.desktopus.user` image label baked in at build time)
- All named Docker volumes — both `persistence_home` and any defined in `volumes:` — are created with desktopus labels (`org.desktopus.managed-by`, `org.desktopus.desktop`, `org.desktopus.volume-type`) so they can be tracked
- Add `desktopus volume ls` and `desktopus volume rm` commands to list and remove desktopus-managed volumes
- Also pre-populates the `image` field in the runtime YAML generated by `desktopus init`

## Usage

```yaml
# desktopus.runtime.yaml
persistence_home: my-desktop-data

volumes:
  - another-named-volume:/some/path    # also labelled and tracked
  - ~/projects:/home/desktopus/projects  # bind mount, not tracked
```

```sh
desktopus volume ls
# NAME              DESKTOP    TYPE
# my-desktop-data   mydesk     home
# another-vol       mydesk     -

desktopus volume rm my-desktop-data
desktopus volume rm my-desktop-data --force
```